### PR TITLE
make tests more stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.org/alphagov/notifications-python-client.svg?branch=master)](https://api.travis-ci.org/alphagov/notifications-python-client.svg?branch=master)
+[![Build Status](https://api.travis-ci.org/alphagov/notifications-python-client.svg?branch=master)](https://travis-ci.org/alphagov/notifications-python-client)
 
 # GOV.UK Notify Python client
 


### PR DESCRIPTION
they were only using freeze_time for half of the interaction - my completely untested assumption is that sometimes they'd fail, and sometimes succeed, depending on whether a second ticked over after time unfreezes.

just use freeze_time the whole time