### PR TITLE
Upgrade testing dependencies

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,8 +1,9 @@
 -r requirements.txt
-pep8==1.5.7
-pytest==2.8.1
-pytest-mock==0.8.1
-pytest-cov==2.2.0
+pep8==1.7.0
+pytest==3.0.2
+pytest-mock==1.2
+pytest-cov==2.3.1
+pytest-xdist==1.15.0
 mock==1.0.1
 freezegun==0.3.5
 requests-mock==0.7.0


### PR DESCRIPTION
As per: https://github.com/alphagov/notifications-api/commit/fa3d4413e7df77cdca7228e18325d0e8efd0bbc3

> requirements should be kept up to date to ensure we get bug fixes and
> new features as they come - particularly py.test, which we were
> running an 18 month old version for, and missing out on some useful
> xfail and fixture enhancements, among other things

Also installs pytest-xdist which includes the very useful `-f` flag to
re-run tests when files change. See:
https://github.com/pytest-dev/pytest-xdist#xdist-pytest-distributed-testing-plugin