### PR TITLE
Instantiate client with combined API key in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ Generate an API key by logging in to
 [GOV.UK Notify](https://www.notifications.service.gov.uk) and going to
 the **API integration** page.
 
-You will find your service ID on the **API integration** page.
-
-
 ## Send a message
 
 Text message:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ pip install git+https://github.com/alphagov/notifications-python-client.git
 ```python
 from notifications_python_client.notifications import NotificationsAPIClient
 
-notifications_client = NotificationsAPIClient(
-    "https://api.notifications.service.gov.uk",
-    service_id=service_id,
-    api_key=api_key
-)
+notifications_client = NotificationsAPIClient(api_key)
 ```
 
 Generate an API key by logging in to


### PR DESCRIPTION
So that users don’t have to worry about:
- base URL
- service ID

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/968