### PR TITLE
Python 2 support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ ensuring the latest version of notifications-api do not break the contract of th
 Use this to test the client without having to create an application.
 
 ```
-    PYTHONPATH=. python /utils/make_api_call.py <base_api_url> <service_id> <api_key> [fetch|create]
+    PYTHONPATH=. python /utils/make_api_call.py <base_api_url> <api_key> [fetch|create]
 ```
 
 This will use the API referred to in the base_api_url argument to send a text message.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ Additionally code coverage is checked via `pytest-cov`.
 
 ## Integration tests
 
-The `./scripts/run_integration_tests.py` script will run the integration tests. 
-The integration tests will test the contract of the response to all the api calls, 
+The `./scripts/run_integration_tests.py` script will run the integration tests.
+The integration tests will test the contract of the response to all the api calls,
 ensuring the latest version of notifications-api do not break the contract of the notifications-python-client.
 
 ## Command line tool

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include Makefile  *.txt *.md
+recursive-include *.py

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ clean-docker-containers: ## Clean up any remaining docker containers
 	docker rm -f $(shell docker ps -q -f "name=${DOCKER_CONTAINER_PREFIX}") 2> /dev/null || true
 
 clean:
-	rm -rf .cache venv dist .eggs build
+	rm -rf .cache venv dist .eggs build .tox
 
 .PHONY: tox-with-docker
 tox-with-docker: prepare-docker-runner-image

--- a/Makefile
+++ b/Makefile
@@ -128,3 +128,17 @@ clean-docker-containers: ## Clean up any remaining docker containers
 
 clean:
 	rm -rf .cache venv dist .eggs build
+
+.PHONY: tox-with-docker
+tox-with-docker: prepare-docker-runner-image
+	docker run -i --rm \
+		--name "${DOCKER_CONTAINER_PREFIX}-integration-test" \
+		-v `pwd`:/var/project \
+		-e http_proxy="${HTTP_PROXY}" \
+		-e HTTP_PROXY="${HTTP_PROXY}" \
+		-e https_proxy="${HTTPS_PROXY}" \
+		-e HTTPS_PROXY="${HTTPS_PROXY}" \
+		-e NO_PROXY="${NO_PROXY}" \
+		--env-file docker.env \
+		${DOCKER_BUILDER_IMAGE_NAME} \
+		tox

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4-slim
+FROM debian:jessie
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -14,13 +14,17 @@ RUN \
 	&& apt-get install -y --no-install-recommends \
 		make \
 		git \
+		python2.7 \
+		python3.4 \
+		python-pip \
+		python3-pip \
 	&& echo "Clean up" \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN \
 	echo "Install global pip packages" \
 	&& pip install \
-		virtualenv
+		tox
 
 
 WORKDIR /var/project

--- a/integration_test/__init__.py
+++ b/integration_test/__init__.py
@@ -1,6 +1,0 @@
-from jsonschema import (Draft4Validator)
-
-
-def validate(json_to_validate, schema):
-    validator = Draft4Validator(schema)
-    validator.validate(json_to_validate, schema)

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -1,14 +1,20 @@
 import os
 import uuid
 
-from integration_test import (validate)
-from integration_test.schemas.v2.notification_schemas import (
+from jsonschema import Draft4Validator
+
+from notifications_python_client.notifications import NotificationsAPIClient
+from schemas.v2.notification_schemas import (
     get_notifications_response,
     get_notification_response,
     post_sms_response,
     post_email_response
 )
-from notifications_python_client.notifications import NotificationsAPIClient
+
+
+def validate(json_to_validate, schema):
+    validator = Draft4Validator(schema)
+    validator.validate(json_to_validate, schema)
 
 
 def send_sms_notification_test_response(python_client):

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -1,4 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE
 
 from notifications_python_client.notifications import NotificationsAPIClient

--- a/notifications_python_client/authentication.py
+++ b/notifications_python_client/authentication.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import int
+from future import standard_library
+standard_library.install_aliases()
 import calendar
 import time
 

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -1,18 +1,20 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+import urllib.parse
 import logging
 import json
+
 from monotonic import monotonic
+import requests
 
 from notifications_python_client.version import __version__
 from notifications_python_client.errors import HTTPError, InvalidResponse
 from notifications_python_client.authentication import create_jwt_token
 
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
-
-import requests
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +32,6 @@ class BaseAPIClient(object):
         :param secret - application secret - used to sign the request:
         :return:
         """
-
         service_id = api_key[-73:-37]
         api_key = api_key[-36:]
 
@@ -71,7 +72,7 @@ class BaseAPIClient(object):
             self.service_id
         )
 
-        url = urlparse.urljoin(self.base_url, url)
+        url = urllib.parse.urljoin(self.base_url, url)
 
         start_time = monotonic()
         try:

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -72,7 +72,7 @@ class BaseAPIClient(object):
             self.service_id
         )
 
-        url = urllib.parse.urljoin(self.base_url, url)
+        url = urllib.parse.urljoin(str(self.base_url), str(url))
 
         start_time = monotonic()
         try:

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import super
+from future import standard_library
+standard_library.install_aliases()
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Request failed"
 
@@ -39,7 +46,7 @@ class APIError(Exception):
     @property
     def message(self):
         try:
-            return self.response.json().get('message',  self.response.json().get('errors'))
+            return self.response.json().get('message', self.response.json().get('errors'))
         except (TypeError, ValueError, AttributeError, KeyError):
             return self._message or REQUEST_ERROR_MESSAGE
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from notifications_python_client.base import BaseAPIClient
 
 

--- a/notifications_python_client/version.py
+++ b/notifications_python_client/version.py
@@ -1,1 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 __version__ = '4.0.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.0.0
 PyJWT>=1
 docopt>=0.3.0
 monotonic>=0.1
+future

--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -11,7 +11,6 @@ echo -n "" > docker.env
 
 env_vars=(
     NOTIFY_API_URL
-    SERVICE_ID
     API_KEY
     FUNCTIONAL_TEST_EMAIL
     FUNCTIONAL_TEST_NUMBER

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,7 @@ test=pytest
 [tool:pytest]
 addopts = --verbose
 python_files = tests/**
+
+[bdist_wheel]
+# this flags the wheel as being python python 2 and 3 compatible
+universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
 max-line-length = 120
-exclude = ./migrations,./venv,./venv3
+exclude = ./migrations,./venv,./venv3,.tox
 
 [aliases]
 test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,5 @@ addopts = --verbose
 python_files = tests/**
 
 [bdist_wheel]
-# this flags the wheel as being python python 2 and 3 compatible
+# this flags the wheel as being python 2 and 3 compatible
 universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [pep8]
 max-line-length = 120
 exclude = ./migrations,./venv,./venv3,.tox
+# E402 module level import not at top of file
+ignore = E402
 
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Development Status :: 4 - Beta',
-        # TODO: Get tests running for other versions of python - using tox?
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 import mock
 
 import requests_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from unittest import mock
+import mock
 
 import requests_mock
 import pytest

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
 import calendar
 import time
 from datetime import datetime, timedelta

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 import requests
-from unittest import mock
+import mock
 
 import pytest
 from notifications_python_client.errors import HTTPError, InvalidResponse

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import str
+from future import standard_library
+standard_library.install_aliases()
 import requests
 import mock
 
@@ -7,16 +14,12 @@ from notifications_python_client.errors import HTTPError, InvalidResponse
 from notifications_python_client.base import BaseAPIClient
 from tests.conftest import API_KEY_ID, SERVICE_ID, COMBINED_API_KEY
 
-EMOJI_API_KEY = '😬'.join(['name_of_key', SERVICE_ID, API_KEY_ID])
-
 
 @pytest.mark.parametrize('client', [
     BaseAPIClient(api_key=COMBINED_API_KEY),
-    BaseAPIClient(api_key=EMOJI_API_KEY),
     BaseAPIClient(COMBINED_API_KEY),
 ], ids=[
     'combined api key',
-    'key with emoji',
     'positional api key'
 ])
 def test_passes_through_service_id_and_key(rmock, client):

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -1,4 +1,4 @@
-from ..conftest import TEST_HOST
+from tests.conftest import TEST_HOST
 
 
 def test_get_notification_by_id(notifications_client, rmock):

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -1,3 +1,9 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
 from tests.conftest import TEST_HOST
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps = -r{toxinidir}/requirements_for_test.txt
 commands =
   {envbindir}/pep8 --exclude=venv,.tox .
   py.test tests/ {posargs}
-# {envbindir}/python integration_test/integration_tests.py
+  {envbindir}/python integration_test/integration_tests.py
 
 # environment variables used by the tests
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
 # environment variables used by the tests
 passenv =
   NOTIFY_API_URL
-  SERVICE_ID
   API_KEY
   FUNCTIONAL_TEST_EMAIL
   FUNCTIONAL_TEST_NUMBER

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist =
+  py27
+  py34
+
+[testenv:py34]
+basepython=python3
+
+[testenv]
+deps = -r{toxinidir}/requirements_for_test.txt
+
+# can't use the scripts directly as they set up the venv dir, and i'm not sure how that'll interact with tox's internal venv
+commands =
+#  {envbindir}/pep8 --exclude=venv,.tox .
+  py.test -s -v tests/
+# {envbindir}/python integration_test/integration_tests.py
+
+# environment variables used by the tests
+passenv =
+  NOTIFY_API_URL
+  SERVICE_ID
+  API_KEY
+  FUNCTIONAL_TEST_EMAIL
+  FUNCTIONAL_TEST_NUMBER
+  EMAIL_TEMPLATE_ID
+  SMS_TEMPLATE_ID

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,6 @@ envlist =
   py27
   py34
 
-[testenv:py34]
-basepython=python3
-
-[testenv:py27]
-basepython=python2.7
-
 [testenv]
 deps = -r{toxinidir}/requirements_for_test.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,16 @@ envlist =
 [testenv:py34]
 basepython=python3
 
+[testenv:py27]
+basepython=python2.7
+
 [testenv]
 deps = -r{toxinidir}/requirements_for_test.txt
 
 # can't use the scripts directly as they set up the venv dir, and i'm not sure how that'll interact with tox's internal venv
 commands =
-#  {envbindir}/pep8 --exclude=venv,.tox .
-  py.test -s -v tests/
+  {envbindir}/pep8 --exclude=venv,.tox .
+  py.test tests/ {posargs}
 # {envbindir}/python integration_test/integration_tests.py
 
 # environment variables used by the tests


### PR DESCRIPTION
🙌 🙌 🙌 🙌 🙌 

We now officially support python 2! Run tests on both 2.7 and 3.4 to ensure conformity

Biggest change is rather than the docker file stemming from python3.4:slim, it now just goes from debian:jessie (python3.4:slim inherits from that), and then apt-gets both python 2 and python 3, and then we use tox.

You can run tox locally by installing it in your env of choice (it doesn't matter, as when you use tox it'll create its own venvs for its tests), and then simply running `tox`, or it runs in docker through the command `make tox-with-docker`

Todo:

- [x] ensure we can build wheels that have the correct python 2.7 compat flags
- [ ] [AFTER MERGE] update jenkins job to run `make tox-with-docker` rather than `make test-with-docker`
- [x] [AFTER MERGE] remove contents of all python-client workspaces and rebuild, so that it picks up docker changes (PR one already done, need to update master / client tests)