### PR TITLE
pass through proxy settings to tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,9 @@ passenv =
   FUNCTIONAL_TEST_NUMBER
   EMAIL_TEMPLATE_ID
   SMS_TEMPLATE_ID
+  # proxy variables used by the tests when run on jenkins
+  http_proxy
+  HTTP_PROXY
+  https_proxy
+  HTTPS_PROXY
+  NO_PROXY


### PR DESCRIPTION
tox manages its own env for #reasons, and on jenkins we need the
http_proxy variables to be set or we won't be able to access preview
to run the integration tests