### PR TITLE
tweak letter error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Otherwise the client will raise a `HTTPError`:
 <pre>
 [{
     "error": "RateLimitError",
-    "message": "Exceeded rate limit for key type TEAM of 10 requests per 10 seconds"
+    "message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"
 }]
 </pre>
 </td>
@@ -371,7 +371,7 @@ Otherwise the client will raise a `HTTPError`:
 <pre>
 [{
     "error": "BadRequestError",
-    "message": "Can"t send to this recipient using a team-only API key"
+    "message": "Cannot send letters with a team api key"
 ]}
 </pre>
 </td>
@@ -384,8 +384,7 @@ Otherwise the client will raise a `HTTPError`:
 <pre>
 [{
     "error": "BadRequestError",
-    "message": "Can"t send to this recipient when service is in trial mode
-                - see https://www.notifications.service.gov.uk/trial-mode"
+    "message": "Cannot send letters when service is in trial mode"
 }]
 </pre>
 </td>


### PR DESCRIPTION
* made the example rate limit not use team key (since that's not allowed for letters)
* changed the team api key and trial mode error messages to be more accurate