### PR TITLE
Update post email with an optional email reply to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.0
+
+* Update to `NotificationsAPIClient.send_email_notification()`
+    * added `email_reply_to_id`: an optional email_reply_to_id specified when adding Email reply to addresses under service settings, if this is not provided the reply to email will be the service default reply to email. `email_reply_to_id` can be omitted.
+
 ## 4.4.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ response = notifications_client.send_email_notification(
     email_address='the_email_address@example.com',
     template_id='f33517ff-2a88-4f6e-b855-c550268ce08a'
     personalisation=None,
-    reference=None
+    reference=None,
+    email_reply_to_id=None
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ An optional identifier you generate. The `reference` can be used as a unique ref
 
 You can omit this argument if you do not require a reference for the notification.
 
+#### `email_reply_to_id`
+
+An optional identifier that you can get from the service email_reply_to ids found  in the service settings / manage email reply to addresses page.
+
+You can omit this argument if you want to use the default service email reply to otherwise add the id from the list of email_reply_to ids associated with the service.
+
 #### `personalisation`
 
 If a template has placeholders, you need to provide their values, for example:

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -35,14 +35,16 @@ def send_sms_notification_test_response(python_client):
     return response['id']
 
 
-def send_email_notification_test_response(python_client):
+def send_email_notification_test_response(python_client, reply_to=None):
     email_address = os.environ['FUNCTIONAL_TEST_EMAIL']
     template_id = os.environ['EMAIL_TEMPLATE_ID']
+    email_reply_to_id = reply_to
     unique_name = str(uuid.uuid4())
     personalisation = {'name': unique_name}
     response = python_client.send_email_notification(email_address=email_address,
                                                      template_id=template_id,
-                                                     personalisation=personalisation)
+                                                     personalisation=personalisation,
+                                                     email_reply_to_id=email_reply_to_id)
     validate(response, post_email_response)
     assert unique_name in response['content']['body']  # check placeholders are replaced
     return response['id']
@@ -145,13 +147,17 @@ def test_integration():
 
     sms_template_id = os.environ['SMS_TEMPLATE_ID']
     email_template_id = os.environ['EMAIL_TEMPLATE_ID']
+    email_reply_to_id = os.environ['EMAIL_REPLY_TO_ID']
     version_number = 1
 
     sms_id = send_sms_notification_test_response(client)
     email_id = send_email_notification_test_response(client)
+    email_with_reply_id = send_email_notification_test_response(client, email_reply_to_id)
     letter_id = send_letter_notification_test_response(client)
+
     get_notification_by_id(client, sms_id, SMS_TYPE)
     get_notification_by_id(client, email_id, EMAIL_TYPE)
+    get_notification_by_id(client, email_with_reply_id, EMAIL_TYPE)
     get_notification_by_id(client, letter_id, EMAIL_TYPE)
 
     get_all_notifications(client)

--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -128,6 +128,7 @@ post_email_request = {
         "reference": {"type": "string"},
         "email_address": {"type": "string", "format": "email_address"},
         "template_id": uuid,
+        "email_reply_to_id": uuid,
         "personalisation": personalisation
     },
     "required": ["email_address", "template_id"]

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
 
-__version__ = '4.4.0'
+__version__ = '4.5.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -26,7 +26,14 @@ class NotificationsAPIClient(BaseAPIClient):
             '/v2/notifications/sms',
             data=notification)
 
-    def send_email_notification(self, email_address, template_id, personalisation=None, reference=None):
+    def send_email_notification(
+        self,
+        email_address,
+        template_id,
+        personalisation=None,
+        reference=None,
+        email_reply_to_id=None
+    ):
         notification = {
             "email_address": email_address,
             "template_id": template_id
@@ -35,6 +42,8 @@ class NotificationsAPIClient(BaseAPIClient):
             notification.update({'personalisation': personalisation})
         if reference:
             notification.update({'reference': reference})
+        if email_reply_to_id:
+            notification.update({'email_reply_to_id': email_reply_to_id})
         return self.post(
             '/v2/notifications/email',
             data=notification)

--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -17,6 +17,7 @@ env_vars=(
     EMAIL_TEMPLATE_ID
     SMS_TEMPLATE_ID
     LETTER_TEMPLATE_ID
+    EMAIL_REPLY_TO_ID
 )
 
 for env_var in "${env_vars[@]}"; do

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -106,4 +106,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.4.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.5.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -148,6 +148,22 @@ def test_create_email_notification(notifications_client, rmock):
     }
 
 
+def test_create_email_notification_with_email_reply_to_id(notifications_client, rmock):
+    endpoint = "{0}/v2/notifications/email".format(TEST_HOST)
+    rmock.request(
+        "POST",
+        endpoint,
+        json={"status": "success"},
+        status_code=200)
+
+    notifications_client.send_email_notification(
+        email_address="to@example.com", template_id="456", email_reply_to_id="789")
+
+    assert rmock.last_request.json() == {
+        'template_id': '456', 'email_address': 'to@example.com', 'email_reply_to_id': '789'
+    }
+
+
 def test_create_email_notification_with_personalisation(notifications_client, rmock):
     endpoint = "{0}/v2/notifications/email".format(TEST_HOST)
     rmock.request(

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ passenv =
   EMAIL_TEMPLATE_ID
   LETTER_TEMPLATE_ID
   SMS_TEMPLATE_ID
+  EMAIL_REPLY_TO_ID
   # proxy variables used by the tests when run on jenkins
   http_proxy
   HTTP_PROXY

--- a/utils/make_api_call.py
+++ b/utils/make_api_call.py
@@ -45,8 +45,13 @@ def create_email_notification(notifications_client):
     personalisation = input("personalisation (as JSON):") or None
     personalisation = personalisation and json.loads(personalisation)
     reference = input("reference string for notification: ")
+    email_reply_to_id = input("email reply to id:")
     return notifications_client.send_email_notification(
-        email_address, template_id=template_id, personalisation=personalisation, reference=reference
+        email_address,
+        template_id=template_id,
+        personalisation=personalisation,
+        reference=reference,
+        email_reply_to_id=email_reply_to_id
     )
 
 


### PR DESCRIPTION
Updated integration and unit tests for python client

Reference - 
Step 6 from this story https://www.pivotaltracker.com/story/show/150440099

NOTE - Requires the email_reply_to_id API endpoint to be available before merging