### PR TITLE
Allow send_sms_notification to accept an sms_sender_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.6.0
+
+### Changed
+
+* Update to `NotificationsAPIClient.send_sms_notification()`
+    * added `sms_sender_id`: an optional `sms_sender_id` specified when adding SMS senders under service settings. If this is not provided, the SMS sender will be the service default SMS sender. `sms_sender_id` can be omitted.
+
 ## 4.5.0
 
 * Update to `NotificationsAPIClient.send_email_notification()`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ response = notifications_client.send_sms_notification(
     phone_number='+447900900123',
     template_id='f33517ff-2a88-4f6e-b855-c550268ce08a',
     personalisation=None,
-    reference=None
+    reference=None,
+    sms_sender_id=None
 )
 ```
 <details>
@@ -152,6 +153,12 @@ personalisation={
     'reference_number': '300241',
 }
 ```
+
+#### `sms_sender_id`
+
+Optional. Specifies the identifier of the sms sender to set for the notification. The identifiers are found in your service Settings, when you 'Manage' your 'Text message sender'.
+
+If you omit this argument your default sms sender will be set for the notification.
 
 </details>
 

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -22,14 +22,16 @@ def validate(json_to_validate, schema):
     validator.validate(json_to_validate, schema)
 
 
-def send_sms_notification_test_response(python_client):
+def send_sms_notification_test_response(python_client, sender_id=None):
     mobile_number = os.environ['FUNCTIONAL_TEST_NUMBER']
     template_id = os.environ['SMS_TEMPLATE_ID']
     unique_name = str(uuid.uuid4())
     personalisation = {'name': unique_name}
+    sms_sender_id = sender_id
     response = python_client.send_sms_notification(phone_number=mobile_number,
                                                    template_id=template_id,
-                                                   personalisation=personalisation)
+                                                   personalisation=personalisation,
+                                                   sms_sender_id=sms_sender_id)
     validate(response, post_sms_response)
     assert unique_name in response['content']['body']  # check placeholders are replaced
     return response['id']
@@ -146,16 +148,19 @@ def test_integration():
     )
 
     sms_template_id = os.environ['SMS_TEMPLATE_ID']
+    sms_sender_id = os.environ['SMS_SENDER_ID']
     email_template_id = os.environ['EMAIL_TEMPLATE_ID']
     email_reply_to_id = os.environ['EMAIL_REPLY_TO_ID']
     version_number = 1
 
     sms_id = send_sms_notification_test_response(client)
+    sms_with_sender_id = send_sms_notification_test_response(client, sms_sender_id)
     email_id = send_email_notification_test_response(client)
     email_with_reply_id = send_email_notification_test_response(client, email_reply_to_id)
     letter_id = send_letter_notification_test_response(client)
 
     get_notification_by_id(client, sms_id, SMS_TYPE)
+    get_notification_by_id(client, sms_with_sender_id, SMS_TYPE)
     get_notification_by_id(client, email_id, EMAIL_TYPE)
     get_notification_by_id(client, email_with_reply_id, EMAIL_TYPE)
     get_notification_by_id(client, letter_id, EMAIL_TYPE)

--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -87,6 +87,7 @@ post_sms_request = {
         "reference": {"type": "string"},
         "phone_number": {"type": "string", "format": "phone_number"},
         "template_id": uuid,
+        "sms_sender_id": uuid,
         "personalisation": personalisation
     },
     "required": ["phone_number", "template_id"]

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '4.5.1'
+__version__ = '4.6.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -13,7 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 class NotificationsAPIClient(BaseAPIClient):
-    def send_sms_notification(self, phone_number, template_id, personalisation=None, reference=None):
+    def send_sms_notification(
+        self,
+        phone_number,
+        template_id,
+        personalisation=None,
+        reference=None,
+        sms_sender_id=None
+    ):
         notification = {
             "phone_number": phone_number,
             "template_id": template_id
@@ -22,6 +29,8 @@ class NotificationsAPIClient(BaseAPIClient):
             notification.update({'personalisation': personalisation})
         if reference:
             notification.update({'reference': reference})
+        if sms_sender_id:
+            notification.update({'sms_sender_id': sms_sender_id})
         return self.post(
             '/v2/notifications/sms',
             data=notification)

--- a/scripts/generate_docker_env.sh
+++ b/scripts/generate_docker_env.sh
@@ -18,6 +18,7 @@ env_vars=(
     SMS_TEMPLATE_ID
     LETTER_TEMPLATE_ID
     EMAIL_REPLY_TO_ID
+    SMS_SENDER_ID
 )
 
 for env_var in "${env_vars[@]}"; do

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -106,4 +106,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.5.1"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.6.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -132,6 +132,23 @@ def test_create_sms_notification_with_personalisation(notifications_client, rmoc
     }
 
 
+def test_create_sms_notification_with_sms_sender_id(notifications_client, rmock):
+    endpoint = "{0}/v2/notifications/sms".format(TEST_HOST)
+    rmock.request(
+        "POST",
+        endpoint,
+        json={"status": "success"},
+        status_code=200)
+
+    notifications_client.send_sms_notification(
+        phone_number="07700 900000", template_id="456", sms_sender_id="789"
+    )
+
+    assert rmock.last_request.json() == {
+        'template_id': '456', 'phone_number': '07700 900000', 'sms_sender_id': '789'
+    }
+
+
 def test_create_email_notification(notifications_client, rmock):
     endpoint = "{0}/v2/notifications/email".format(TEST_HOST)
     rmock.request(

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
   LETTER_TEMPLATE_ID
   SMS_TEMPLATE_ID
   EMAIL_REPLY_TO_ID
+  SMS_SENDER_ID
   # proxy variables used by the tests when run on jenkins
   http_proxy
   HTTP_PROXY

--- a/utils/make_api_call.py
+++ b/utils/make_api_call.py
@@ -9,6 +9,7 @@ Options:
     --template=<4051caf5-3c65-4dd3-82d7-31c8c8e82e27>
     --personalisation=<{}>
     --reference=<''>
+    --sms_sender_id=<''>
 
 Example:
     ./make_api_call.py http://api my_service super_secret \
@@ -42,8 +43,13 @@ def create_sms_notification(notifications_client, **kwargs):
     personalisation = kwargs['--personalisation'] or input("personalisation (JSON string):")
     personalisation = personalisation and json.loads(personalisation)
     reference = kwargs['--reference'] if kwargs['--reference'] is not None else input("reference string for notification: ")  # noqa
+    sms_sender_id = kwargs['--sms_sender_id'] or input("sms sender id: ")
     return notifications_client.send_sms_notification(
-        mobile_number, template_id=template_id, personalisation=personalisation, reference=reference
+        mobile_number,
+        template_id=template_id,
+        personalisation=personalisation,
+        reference=reference,
+        sms_sender_id=sms_sender_id,
     )
 
 


### PR DESCRIPTION
When using the `send_sms_notification` function, you can now choose to specify which
sender you want the notification to come from by passing in an `sms_sender_id`. If this 
is not included, the sms notification will come from the default sender.

[Pivotal story](https://www.pivotaltracker.com/story/show/152106587)
