### PR TITLE
Updated the response to match that on API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.8.1
+
+* Added post_precompiled_letter_response and updated integration tests
+    * The API now only returns notification id and client reference, so updated the response scheme to match
+
 ## 4.8.0
 
 * Added `NotificationsAPIClient.send_precompiled_letter_notification()`

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ personalisation={
 
 ### Precompiled Letter
 
+This is an invitation only feature, for more information contact us via[https://www.notifications.service.gov.uk/support](https://www.notifications.service.gov.uk/support).
+
 #### Method
 
 <details>
@@ -359,18 +361,7 @@ Click here to expand for more information.
 ```python
 {
   "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
-  "reference": "your-letter-reference",
-  "content": {
-    "subject": "Licence renewal",
-    "body": "Dear Bill, your licence is due for renewal on 3 January 2016.",
-  },
-  "uri": "https://api.notifications.service.gov.uk/v2/notifications/740e5834-3a29-46b4-9a6f-16142fde533a",
-  "template": {
-    "id": "f33517ff-2a88-4f6e-b855-c550268ce08a",
-    "version": 1,
-    "uri": "https://api.notifications.service.gov.uk/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a"
-  }
-  "scheduled_for": None
+  "reference": "your-letter-reference"
 }
 ```
 

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -72,7 +72,7 @@ def send_letter_notification_test_response(python_client):
 
 def send_precompiled_letter_notification_test_response(python_client):
     unique_name = str(uuid.uuid4())
-    with open('integrations_test/test_files/one_page_pdf.pdf', "rb") as pdf_file:
+    with open('integration_test/test_files/one_page_pdf.pdf', "rb") as pdf_file:
         response = python_client.send_precompiled_letter_notification(
             reference=unique_name,
             pdf_file=pdf_file

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -9,8 +9,8 @@ from integration_test.schemas.v2.notification_schemas import (
     post_email_response,
     post_letter_response,
     get_notification_response,
-    get_notifications_response
-)
+    get_notifications_response,
+    post_precompiled_letter_response)
 from integration_test.schemas.v2.template_schemas import get_template_by_id_response, post_template_preview_response
 from integration_test.schemas.v2.templates_schemas import get_all_template_response
 from integration_test.enums import SMS_TYPE, EMAIL_TYPE, LETTER_TYPE
@@ -72,12 +72,12 @@ def send_letter_notification_test_response(python_client):
 
 def send_precompiled_letter_notification_test_response(python_client):
     unique_name = str(uuid.uuid4())
-    with open('integration_test/test_files/one_page_pdf.pdf', "rb") as pdf_file:
+    with open('test_files/one_page_pdf.pdf', "rb") as pdf_file:
         response = python_client.send_precompiled_letter_notification(
             reference=unique_name,
             pdf_file=pdf_file
         )
-    validate(response, post_letter_response)
+    validate(response, post_precompiled_letter_response)
     assert unique_name in response['reference']
     return response['id']
 

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -72,7 +72,7 @@ def send_letter_notification_test_response(python_client):
 
 def send_precompiled_letter_notification_test_response(python_client):
     unique_name = str(uuid.uuid4())
-    with open('test_files/one_page_pdf.pdf', "rb") as pdf_file:
+    with open('integrations_test/test_files/one_page_pdf.pdf', "rb") as pdf_file:
         response = python_client.send_precompiled_letter_notification(
             reference=unique_name,
             pdf_file=pdf_file

--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -203,6 +203,18 @@ post_letter_response = {
     "required": ["id", "content", "uri", "template"]
 }
 
+post_precompiled_letter_response = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "POST letter notification response schema",
+    "type": "object",
+    "title": "response v2/notifications/letter",
+    "properties": {
+        "id": uuid,
+        "reference": {"type": ["string", "null"]},
+    },
+    "required": ["id", "reference"]
+}
+
 
 def create_post_sms_response_from_notification(notification, body, from_number, url_root):
     return {"id": notification.id,

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '4.8.0'
+__version__ = '4.8.1'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -106,4 +106,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.8.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.8.1"


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

The API has been updated so that the precompiled response to only includes the notification id and the client reference.

* Added a new schema for the precompiled response
* Updated Readme
* Updated the unit and integration tests
* Updated the change log


## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `README.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
