### PR TITLE
Add support for attaching documents to email notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.9.0
+
+* Add support for document uploads in `send_email_notification`
+
 ## 4.8.2
 
 * Fix issues when installing with pip 10.0.0

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -158,6 +158,17 @@ personalisation={
 }
 ```
 
+If your service has a permission to upload documents you can pass file objects as values for the personalisation keys:
+
+```python
+with open('file.pdf', 'rb') as f:
+    ...
+    personalisation={
+      'first_name': 'Amala',
+      'document': f,
+    }
+```
+
 #### reference (optional)
 
 A unique identifier. This reference can identify a single unique notification or a batch of multiple notifications.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -181,26 +181,24 @@ email_reply_to_id='8e222534-7f05-4972-86e3-17c5d9f894e2' # optional UUID string
 
 If you omit this argument, the client will set your default email reply-to address for the notification.
 
-### Attach a document
+### Upload a document
 
-You can attach a document to an email notification.
+You can upload a document to link to from an email notification.
 
-Contact the GOV.UK Notify team on the support page or through the Slack channel to enable this function for your service.
+The document must be a PDF file smaller than 2MB.
 
-The document must be a PDF file smaller than 2MB. To attach the document, you must:
-
-1. Define the PDF as a file object.
-1. Pass the file object as a value into the personalisation argument. For example:
+To upload the document, pass the file object as a value into the personalisation argument. For example:
 
         ```python
-        with open('file.pdf', 'rb') as DOCUMENT_NAME:
+        with open('file.pdf', 'rb') as f:
             ...
             personalisation={
               'first_name': 'Amala',
               'application_date': '2018-01-01',
-              'document': DOCUMENT_NAME,
+              'document': f,
             }
         ```
+Contact the GOV.UK Notify team on the support page or through the Slack channel to enable this function for your service.
 
 ### Response
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -158,17 +158,6 @@ personalisation={
 }
 ```
 
-If your service has a permission to upload documents you can pass file objects as values for the personalisation keys:
-
-```python
-with open('file.pdf', 'rb') as f:
-    ...
-    personalisation={
-      'first_name': 'Amala',
-      'document': f,
-    }
-```
-
 #### reference (optional)
 
 A unique identifier. This reference can identify a single unique notification or a batch of multiple notifications.
@@ -192,6 +181,27 @@ email_reply_to_id='8e222534-7f05-4972-86e3-17c5d9f894e2' # optional UUID string
 
 If you omit this argument, the client will set your default email reply-to address for the notification.
 
+### Attach a document
+
+You can attach a document to an email notification.
+
+Contact the GOV.UK Notify team on the support page or through the Slack channel to enable this function for your service.
+
+The document must be a PDF file smaller than 2MB. To attach the document, you must:
+
+1. Define the PDF as a file object.
+1. Pass the file object as a value into the personalisation argument. For example:
+
+        ```python
+        with open('file.pdf', 'rb') as DOCUMENT_NAME:
+            ...
+            personalisation={
+              'first_name': 'Amala',
+              'application_date': '2018-01-01',
+              'document': DOCUMENT_NAME,
+            }
+        ```
+
 ### Response
 
 If the request to the client is successful, you will receive the following `dict` response:
@@ -214,7 +224,6 @@ If the request to the client is successful, you will receive the following `dict
 }
 ```
 
-
 ### Error codes
 
 If the request is not successful, the client will raise an `HTTPError`.
@@ -223,6 +232,8 @@ If the request is not successful, the client will raise an `HTTPError`.
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`]}`|Use the correct type of API key. Refer to [API keys](#api-keys) for more information|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Refer to [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode) for more information|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported document type '{}'. Supported types are: {}"`<br>`}]`|The attached document must be a PDF file|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Document didn't pass the virus scan"`<br>`}]`|The attached document must be virus free|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](#api-rate-limits) for more information|

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '4.8.2'
+__version__ = '4.9.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from future import standard_library
 standard_library.install_aliases()
 import base64
+import io
 import logging
 import re
 
@@ -49,6 +50,12 @@ class NotificationsAPIClient(BaseAPIClient):
             "template_id": template_id
         }
         if personalisation:
+            personalisation = personalisation.copy()
+            for key in personalisation:
+                if isinstance(personalisation[key], io.IOBase):
+                    personalisation[key] = {
+                        'file': base64.b64encode(personalisation[key].read()).decode('ascii')
+                    }
             notification.update({'personalisation': personalisation})
         if reference:
             notification.update({'reference': reference})

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -106,4 +106,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.8.2"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.9.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 import base64
+import io
 from future import standard_library
 from mock import Mock
 standard_library.install_aliases()
@@ -233,6 +234,35 @@ def test_create_email_notification_with_personalisation(notifications_client, rm
 
     assert rmock.last_request.json() == {
         'template_id': '456', 'email_address': 'to@example.com', 'personalisation': {'name': 'chris'}
+    }
+
+
+def test_create_email_notification_with_document_upload(notifications_client, rmock):
+    endpoint = "{0}/v2/notifications/email".format(TEST_HOST)
+    rmock.request(
+        "POST",
+        endpoint,
+        json={"status": "success"},
+        status_code=200)
+
+    if hasattr(io, 'BytesIO'):
+        mock_file = io.BytesIO(b'file-contents')
+    else:
+        mock_file = io.StringIO('file-contents')
+
+    notifications_client.send_email_notification(
+        email_address="to@example.com", template_id="456", personalisation={
+            'name': 'chris',
+            'doc': mock_file
+        }
+    )
+
+    assert rmock.last_request.json() == {
+        'template_id': '456', 'email_address': 'to@example.com',
+        'personalisation': {
+            'name': 'chris',
+            'doc': {'file': 'ZmlsZS1jb250ZW50cw=='}
+        }
     }
 
 


### PR DESCRIPTION
It's already possible to use the new Document Download integration
in the existing python client by setting a personalisation value to
`{"file": ...}`.

This simplifies the interface by recognizing file-like objects in
personalisation data and automatically reading/converting them to
the format expected by the Notify API:

```python

with open(<document-path>, 'rb') as f:
   client.send_email_notification(..., personalisation={'doc': f})

```

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
