### PR TITLE
Update responses when getting notifications and bump version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.10.0
+
+* Added `created_by_name` to the response for `NotificationsAPIClient.get_notification_by_id()` and `NotificationsAPIClient.get_all_notifications()`
+    * If the notification was sent manually, this will be the name of the sender. If the notification was sent through the API this will be `None`.
+
 ## 4.9.0
 
 * Add support for document uploads in `send_email_notification`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -426,6 +426,7 @@ If the request to the client is successful, the client will return a `dict`:
   "body": "STRING", # required string - body of notification
   "subject": "STRING" # required string for email - subject of email
   "created_at": "STRING", # required string - date and time notification created
+  "created_by_name": "STRING", # optional string - name of the person who sent the notification if sent manually
   "sent_at": "STRING", # optional string - date and time notification sent to provider
   "completed_at:" "STRING" # optional string - date and time notification delivered or failed
 }
@@ -567,8 +568,9 @@ If the request to the client is successful, the client will return a `dict`.
       "body": "STRING", # required string - body of notification
       "subject": "STRING" # required string for email - subject of email
       "created_at": "STRING", # required string - date and time notification created
+      "created_by_name": "STRING", # optional string - name of the person who sent the notification if sent manually
       "sent_at": " STRING", # optional string - date and time notification sent to provider
-      "Completed_at": "STRING" # optional string - date and time notification delivered or failed
+      "completed_at": "STRING" # optional string - date and time notification delivered or failed
     },
     …
   ],

--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -38,7 +38,8 @@ get_notification_response = {
         "subject": {"type": ["string", "null"]},
         "created_at": {"type": "string"},
         "sent_at": {"type": ["string", "null"]},
-        "completed_at": {"type": ["string", "null"]}
+        "completed_at": {"type": ["string", "null"]},
+        "created_by_name": {"type": ["string", "null"]}
     },
     "required": [
         # technically, all keys are required since we always have all of them

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '4.9.0'
+__version__ = '4.10.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -106,4 +106,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.9.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/4.10.0"


### PR DESCRIPTION
The `get_notification_by_id` and `get_all_notifications` methods now
return a new field, `created_by_name`, so this has been documented and
the schema for the integration tests updated.

The version has been bumped from `4.9.0` to `4.10.0` as a result.