### PR TITLE
Rename document upload placeholder in documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -201,7 +201,7 @@ with open('file.pdf', 'rb') as f:
     personalisation={
       'first_name': 'Amala',
       'application_date': '2018-01-01',
-      'document': prepare_upload(f),
+      'link_to_document': prepare_upload(f),
     }
 ```
 


### PR DESCRIPTION
`'document'` key sounds special and doesn't explain that the value that the placeholder ends up with is a link to an uploaded document.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
