### PR TITLE
Remove empty payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+* Change `BaseAPIClient.request` method to only add use the `data` and `params` arguments if they are not `None`, in order to avoid sending GET requests with a body of `'null'`, since these are rejected by Cloudfront.
+
 ## 5.0.0
 
 * Changed the way documents are added to the personalisation data. A new `prepare_upload` function has to be called for each document upload to prepare the file data to be sent to the Notify API.

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.0.0'
+__version__ = '5.0.1'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -65,12 +65,20 @@ class BaseAPIClient(object):
 
         logger.debug("API request {} {}".format(method, url))
 
-        payload = json.dumps(data)
-
         api_token = create_jwt_token(
             self.api_key,
             self.service_id
         )
+
+        kwargs = {
+            "headers": self.generate_headers(api_token),
+        }
+
+        if data is not None:
+            kwargs.update(data=json.dumps(data))
+
+        if params is not None:
+            kwargs.update(params=params)
 
         url = urllib.parse.urljoin(str(self.base_url), str(url))
 
@@ -79,9 +87,7 @@ class BaseAPIClient(object):
             response = requests.request(
                 method,
                 url,
-                headers=self.generate_headers(api_token),
-                data=payload,
-                params=params
+                **kwargs
             )
             response.raise_for_status()
         except requests.RequestException as e:

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.0.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.0.1"

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -97,6 +97,17 @@ def test_invalid_json_raises_api_error(base_client, rmock):
     assert e.value.status_code == 200
 
 
+def test_get_is_not_sent_with_body(base_client, rmock):
+    rmock.request(
+        "GET",
+        "http://test-host/",
+        json={},
+        status_code=200)
+
+    base_client.request('GET', '/')
+    assert rmock.last_request.body is None
+
+
 def test_user_agent_is_set(base_client, rmock):
     rmock.request(
         "GET",


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?

Don't send an empty payload

Currently all our get/post/put/delete methods are an abstraction over a
generic `request` method which defaults to `None` for its `data` and
`params` arguments.

While each of the get/post/put/delete use only one of these arguments,
that has the uninteneded side-effect that GET requests are sent with a
body which is the json representation of `None`:

```python
>>> import json
>>> json.dumps(None)
'null'
```

This behaviour causes problems with Cloudfront which does not accept GET
requests that include a body and returns a 403 [1].

1: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustom-get-body

<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [ ] ~`DOCUMENTATION.md`~
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] ~I've added new environment variables to~
  - [ ] ~`notifications-python-client/scripts/generate_docker_env.sh`~
  - [ ] ~`notifications-python-client/tox.ini`~
  - [ ] ~`CONTRIBUTING.md`~
