### PR TITLE
Return 'name' when fetching a template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.1.0
+
+* Added `name` to the response for `NotificationsAPIClient.get_template_by_id()` and `NotificationsAPIClient.get_template_version()`
+    * These functions now return the template name
+
 ## 5.0.1
 
 * Change `BaseAPIClient.request` method to only add use the `data` and `params` arguments if they are not `None`, in order to avoid sending GET requests with a body of `'null'`, since these are rejected by Cloudfront.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -649,7 +649,8 @@ If the request to the client is successful, the client returns a `dict`.
 
 ```python
 {
-    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
+    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+    "name": "STRING", # required string - template name
     "type": "sms / email / letter" , # required string
     "created_at": "STRING", # required string - date and time template created
     "updated_at": "STRING", # required string - date and time template last updated
@@ -700,7 +701,8 @@ If the request to the client is successful, the client returns a `dict`.
 
 ```python
 {
-    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
+    "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+    "name": "STRING", # required string - template name
     "type": "sms / email / letter" , # required string
     "created_at": "STRING", # required string - date and time template created
     "updated_at": "STRING", # required string - date and time template last updated
@@ -752,14 +754,15 @@ If the request to the client is successful, the client returns a `dict`.
 {
     "templates": [
         {
-            "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID
-    		"type": "sms / email / letter" , # required string
-    		"created_at": "STRING", # required string - date and time template created
-    		"updated_at": "STRING", # required string - date and time template last updated
-    		"version": NUMBER, # required string - template version
-    		"created_by": "someone@example.com", # required string
-    		"body": "STRING", # required string - body of notification
-    		"subject": "STRING" # required string for email - subject of email
+            "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a', # required string - template ID
+            "name": "STRING", # required string - template name
+            "type": "sms / email / letter" , # required string
+            "created_at": "STRING", # required string - date and time template created
+            "updated_at": "STRING", # required string - date and time template last updated
+            "version": NUMBER, # required string - template version
+            "created_by": "someone@example.com", # required string
+            "body": "STRING", # required string - body of notification
+            "subject": "STRING" # required string for email - subject of email
         },
         {
             ...another template

--- a/integration_test/schemas/v2/template_schemas.py
+++ b/integration_test/schemas/v2/template_schemas.py
@@ -21,6 +21,7 @@ get_template_by_id_response = {
     "title": "reponse v2/template",
     "properties": {
         "id": uuid,
+        "name": {"type": "string"},
         "type": {"enum": TEMPLATE_TYPES},
         "created_at": {
             "format": "date-time",

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.0.1'
+__version__ = '5.1.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.0.1"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.1.0"


### PR DESCRIPTION
The name of the template is now returned by these two functions:
* `get_template_by_id()`
* `get_template_version()`

No changes to the code are necessary to make this work, but this PR updates the documentation and bumps the version. 

[Pivotal story](https://www.pivotaltracker.com/story/show/160020331)