### PR TITLE
Remove backticks from precomp letter subheads

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -368,7 +368,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
 
 
-## Send a precompiled Letter
+## Send a pre-compiled letter
 
 This is an invitation-only feature. Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) for more information.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -383,11 +383,11 @@ response = notifications_client.send_precompiled_letter_notification(
 
 ### Arguments
 
-##### `reference` (required)
+##### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
-#### `pdf_file` (required)
+#### pdf_file (required)
 
 The precompiled letter must be a PDF file.
 


### PR DESCRIPTION
## What problem does the pull request solve?

Remove backticks from pre-compiled letter subheads. This is to make the sub-headings consistent with other sub-headings in the document

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
