### PR TITLE
Add prepare upload file size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.0
+
+* Add a document size check to `prepare_upload`. Will raise `ValueError` when trying to upload a document larger than 2MB.
+
 ## 5.1.0
 
 * Added `name` to the response for `NotificationsAPIClient.get_template_by_id()` and `NotificationsAPIClient.get_template_version()`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -261,6 +261,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](#api-rate-limits) for more information|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (LIMIT NUMBER) for today"`<br>`}]`|Refer to [service limits](#service-limits) for the limit number|
 |`500`|`[{`<br>`"error": "Exception",`<br>`"message": "Internal server error"`<br>`}]`|Notify was unable to process the request, resend your notification.|
+|-|`ValueError('Document is larger than 2MB')`|Document size was too large, upload a smaller document.|
 
 ## Send a letter
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.1.0'
+__version__ = '5.2.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/utils.py
+++ b/notifications_python_client/utils.py
@@ -1,7 +1,14 @@
 import base64
 
+DOCUMENT_UPLOAD_SIZE_LIMIT = 2 * 1024 * 1024
+
 
 def prepare_upload(f):
+    contents = f.read()
+
+    if len(contents) > DOCUMENT_UPLOAD_SIZE_LIMIT:
+        raise ValueError('Document is larger than 2MB')
+
     return {
-        'file': base64.b64encode(f.read()).decode('ascii')
+        'file': base64.b64encode(contents).decode('ascii')
     }

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.1.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.2.0"

--- a/tests/notifications_python_client/test_utils.py
+++ b/tests/notifications_python_client/test_utils.py
@@ -1,0 +1,11 @@
+import io
+import pytest
+
+from notifications_python_client import prepare_upload
+
+
+def test_prepare_upload_raises_an_error_for_large_files():
+    with pytest.raises(ValueError) as exc:
+        prepare_upload(io.BytesIO(b'a' * 3 * 1024 * 1024))
+
+    assert 'larger than 2MB' in str(exc.value)


### PR DESCRIPTION
### Check that uploaded documents are smaller than the size limit

Since we can't guarantee that users will see the original 413 error message from document download we're implementing a file size check in the `prepare_upload` helper in all API clients.

### Bump version to 5.2.0

This is technically a breaking change since it's replacing one exception with another, but we know `prepare_upload` is unused at the moment and after `5.0.1` we need to make it less scary for users to upgrade clients.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`

