### PR TITLE
Set postage for precompiled letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.3.0
+
+* Add an optional `postage` argument to `send_precompiled_letter_notification` method.
+* Add postage to the response of `send_precompiled_letter_notification`
+
 ## 5.2.0
 
 * Add a document size check to `prepare_upload`. Will raise `ValueError` when trying to upload a document larger than 2MB.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ The `./scripts/run_tests.py` script will run all the tests.
 [`py.test`](http://pytest.org/latest/) is used for testing.
 
 Running the script will also check for conformance with
-[`pep8`](https://www.python.org/dev/peps/pep-0008/).
+[`flake8`](https://pypi.org/project/flake8/).
 
 Additionally code coverage is checked via `pytest-cov`.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -382,13 +382,14 @@ This is an invitation-only feature. Contact the GOV.UK Notify team on the [suppo
 ```python
 response = notifications_client.send_precompiled_letter_notification(
     reference,      # Reference to identify the notification
-    pdf_file        # PDF File object
+    pdf_file,       # PDF File object
+    postage         # set postage on your precompiled letter
 )
 ```
 
 ### Arguments
 
-##### reference (required)
+#### reference (required)
 
 A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. 
 
@@ -403,6 +404,12 @@ with open("path/to/pdf_file", "rb") as pdf_file:
     )
 ```
 
+#### postage (optional)
+
+You can choose first or second class postage for your precompiled letter. Set the value to `first` for first class, or `second` for second class. If you do not pass in this argument, the postage will default to second class.
+
+
+
 ### Response
 
 If the request to the client is successful, the client returns a `dict`:
@@ -410,7 +417,8 @@ If the request to the client is successful, the client returns a `dict`:
 ```python
 {
   "id": "740e5834-3a29-46b4-9a6f-16142fde533a",
-  "reference": "your-letter-reference"
+  "reference": "your-letter-reference",
+  "postage": "postage-you-have-set-or-None"
 }
 ```
 
@@ -425,6 +433,7 @@ If the request is not successful, the client returns an HTTPError containing the
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`]}`|PDF file format is required|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|Add a `reference` argument to the method call|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send precompiled letters"`<br>`}]`|Contact the GOV.UK Notify team|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (50) for today"`<br>`}]`|Refer to [service limits](#service-limits) for the limit number|

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -82,6 +82,19 @@ def send_precompiled_letter_notification_test_response(python_client):
     return response['id']
 
 
+def send_precompiled_letter_notification_set_postage_test_response(python_client):
+    unique_name = str(uuid.uuid4())
+    with open('integration_test/test_files/one_page_pdf.pdf', "rb") as pdf_file:
+        response = python_client.send_precompiled_letter_notification(
+            reference=unique_name,
+            pdf_file=pdf_file,
+            postage="first"
+        )
+    validate(response, post_precompiled_letter_response)
+    assert "first" in response['postage']
+    return response['id']
+
+
 def get_notification_by_id(python_client, id, notification_type):
     response = python_client.get_notification_by_id(id)
     if notification_type == EMAIL_TYPE:
@@ -195,6 +208,7 @@ def test_integration():
     email_with_reply_id = send_email_notification_test_response(client, email_reply_to_id)
     letter_id = send_letter_notification_test_response(client)
     precompiled_letter_id = send_precompiled_letter_notification_test_response(client)
+    precompiled_letter_with_postage_id = send_precompiled_letter_notification_set_postage_test_response(client)
 
     get_notification_by_id(client, sms_id, SMS_TYPE)
     get_notification_by_id(client, sms_with_sender_id, SMS_TYPE)
@@ -202,6 +216,7 @@ def test_integration():
     get_notification_by_id(client, email_with_reply_id, EMAIL_TYPE)
     get_notification_by_id(client, letter_id, LETTER_TYPE)
     get_notification_by_id(client, precompiled_letter_id, LETTER_TYPE)
+    get_notification_by_id(client, precompiled_letter_with_postage_id, LETTER_TYPE)
 
     get_all_notifications(client)
 

--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -31,6 +31,7 @@ get_notification_response = {
         "line_5": {"type": ["string", "null"]},
         "line_6": {"type": ["string", "null"]},
         "postcode": {"type": ["string", "null"]},
+        "postage": {"enum": ["first", "second", None]},
         "type": {"enum": ["sms", "letter", "email"]},
         "status": {"type": "string"},
         "template": template,
@@ -212,6 +213,7 @@ post_precompiled_letter_response = {
     "properties": {
         "id": uuid,
         "reference": {"type": ["string", "null"]},
+        "postage": {"enum": ["first", "second", None]}
     },
     "required": ["id", "reference"]
 }

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.2.0'
+__version__ = '5.3.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -70,12 +70,15 @@ class NotificationsAPIClient(BaseAPIClient):
             data=notification
         )
 
-    def send_precompiled_letter_notification(self, reference, pdf_file):
+    def send_precompiled_letter_notification(self, reference, pdf_file, postage=None):
         content = base64.b64encode(pdf_file.read()).decode('utf-8')
         notification = {
             "reference": reference,
             "content": content
         }
+
+        if postage:
+            notification["postage"] = postage
 
         return self.post(
             '/v2/notifications/letter',

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.2.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.3.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -363,6 +363,30 @@ def test_send_precompiled_letter_notification(notifications_client, rmock, mocke
     }
 
 
+def test_send_precompiled_letter_notification_sets_postage(notifications_client, rmock, mocker):
+    endpoint = "{0}/v2/notifications/letter".format(TEST_HOST)
+    rmock.request(
+        "POST",
+        endpoint,
+        json={"status": "success"},
+        status_code=200)
+    mock_file = Mock(
+        read=Mock(return_value=b'file_contents'),
+    )
+
+    notifications_client.send_precompiled_letter_notification(
+        reference='Baz',
+        pdf_file=mock_file,
+        postage='first'
+    )
+
+    assert rmock.last_request.json() == {
+        'reference': 'Baz',
+        'content': base64.b64encode(b'file_contents').decode('utf-8'),
+        'postage': 'first'
+    }
+
+
 def test_get_all_notifications_iterator_calls_get_notifications(notifications_client, rmock):
     endpoint = "{0}/v2/notifications".format(TEST_HOST)
     rmock.request(


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Add an optional `postage` argument to send_precompiled_letter_notification method to allow our users to choose postage on precompiled letter they are sending.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
