### PR TITLE
Changes re precompiled letters

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -377,8 +377,6 @@ If the request is not successful, the client returns an `HTTPError` containing t
 
 ## Send a precompiled letter
 
-This is an invitation-only feature. Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) for more information.
-
 ### Method
 
 ```python
@@ -430,13 +428,11 @@ If the request is not successful, the client returns an HTTPError containing the
  
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send precompiled letters"`<br>`]}`|This is an invitation-only feature. Contact the GOV.UK Notify team on the [support page](https://www.notifications.service.gov.uk/support) or through the [Slack channel](https://ukgovernmentdigital.slack.com/messages/govuk-notify) for more information| 
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)| 
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`]}`|PDF file format is required|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|Add a `reference` argument to the method call|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "postage invalid. It must be either first or second."`<br>`}]`|Change the value of `postage` argument in the method call to either 'first' or 'second'|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Service is not allowed to send precompiled letters"`<br>`}]`|Contact the GOV.UK Notify team|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type live of 10 requests per 20 seconds"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "TooManyRequestsError",`<br>`"message": "Exceeded send limits (50) for today"`<br>`}]`|Refer to [service limits](#service-limits) for the limit number|
 


### PR DESCRIPTION
## What problem does the pull request solve?

https://www.pivotaltracker.com/story/show/165763522:

- Remove content stating that precompiled letters are invite only
- Remove error codes stating that your service is not allowed to send precompiled letters

## Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
