### PR TITLE
Get letter pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.4.0
+
+* Add `NotificationsAPIClient.get_letter_pdf(id)`
+    * Returns a `BytesIO`
+    * Will raise a BadRequestError if the PDF is not available
+
+
 ## 5.3.0
 
 * Add an optional `postage` argument to `send_precompiled_letter_notification` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.4.0
 
-* Add `NotificationsAPIClient.get_letter_pdf(id)`
+* Add `NotificationsAPIClient.get_pdf_for_letter(id)`
     * Returns a `BytesIO`
     * Will raise a BadRequestError if the PDF is not available
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -711,7 +711,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 This returns the pdf contents of a letter notification.
 
 ```python
-pdf_file = notifications_client.get_letter_pdf(
+pdf_file = notifications_client.get_pdf_for_letter(
   'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - notification ID
 )
 ```
@@ -740,8 +740,9 @@ If the request is not successful, the client will return an `HTTPError` containi
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letter, try again later"`<br>`}]`|Wait for the notification to finish processing. This usually takes a few seconds|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letters in status virus-scan-failed"`<br>`}]`|You cannot retrieve the contents of a letter notification that contains a virus|
+|`400`|`[{`<br>`"error": "PDFNotReadyError",`<br>`"message": "PDF not available yet, try again later"`<br>`}]`|Wait for the notification to finish processing. This usually takes a few seconds|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Document did not pass the virus scan"`<br>`}]`|You cannot retrieve the contents of a letter notification that contains a virus|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letters in technical-failure"`<br>`}]`|You cannot retrieve the contents of a letter notification in technical-failure|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Notification is not a letter"`<br>`}]`|Check that you are looking up the correct notification|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -205,7 +205,7 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 
 #### Add a placeholder field to the template
 
-1. Sign in to [GOV.UK Notify](https://www.notifications.service.gov.uk/). 
+1. Sign in to [GOV.UK Notify](https://www.notifications.service.gov.uk/).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Add a placeholder field to the email template using double brackets. For example:
 
@@ -330,9 +330,9 @@ The following parameters in the letter recipient's address are optional:
 
 ```python
 personalisation={
-    'address_line_3': '123 High Street', 	
-    'address_line_4': 'Richmond upon Thames', 	
-    'address_line_5': 'London', 		
+    'address_line_3': '123 High Street',
+    'address_line_4': 'Richmond upon Thames',
+    'address_line_5': 'London',
     'address_line_6': 'Middlesex',
 }
 ```
@@ -391,7 +391,7 @@ response = notifications_client.send_precompiled_letter_notification(
 
 #### reference (required)
 
-A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address. 
+A unique identifier you create. This reference identifies a single unique notification or a batch of notifications. It must not contain any personal information such as name or postal address.
 
 #### pdf_file (required)
 
@@ -425,10 +425,10 @@ If the request to the client is successful, the client returns a `dict`:
 ### Error codes
 
 If the request is not successful, the client returns an HTTPError containing the relevant error code.
- 
+
 |error.status_code|error.message|How to fix|
 |:---|:---|:---|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)| 
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Letter content is not a valid PDF"`<br>`]}`|PDF file format is required|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "reference is a required property"`<br>`}]`|Add a `reference` argument to the method call|
@@ -704,6 +704,49 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 
 
+## Get a PDF for a letter notification
+
+### Method
+
+This returns the pdf contents of a letter notification.
+
+```python
+pdf_file = notifications_client.get_letter_pdf(
+  'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - notification ID
+)
+```
+
+### Arguments
+
+#### notification_id (required)
+
+The ID of the notification. You can find the notification ID in the response to the [original notification method call](/python.html#get-the-status-of-one-message-response).
+
+You can also find it in your [GOV.UK Notify Dashboard](https://www.notifications.service.gov.uk).
+
+1. Sign into GOV.UK Notify and select __Dashboard__.
+1. Select __letters sent__.
+1. Select the relevant notification.
+1. Copy the notification ID from the end of the page URL, for example `https://www.notifications.service.gov.uk/services/af90d4cb-ae88-4a7c-a197-5c30c7db423b/notification/ID`.
+
+### Response
+
+If the request to the client is successful, the client will return a `io.BytesIO` object containing the raw PDF data.
+
+### Error codes
+
+If the request is not successful, the client will return an `HTTPError` containing the relevant error code:
+
+|error.status_code|error.message|How to fix|
+|:---|:---|:---|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "id is not a valid UUID"`<br>`}]`|Check the notification ID|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letter, try again later"`<br>`}]`|Wait for the notification to finish processing. This usually takes a few seconds|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "PDF not available for letters in status virus-scan-failed"`<br>`}]`|You cannot retrieve the contents of a letter notification that contains a virus|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Notification is not a letter"`<br>`}]`|Check that you are looking up the correct notification|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
+|`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: signature, api token not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
+|`404`|`[{`<br>`"error": "NoResultFound",`<br>`"message": "No result found"`<br>`}]`|Check the notification ID|
+
 # Get a template
 
 ## Get a template by ID
@@ -722,7 +765,7 @@ response = notifications_client.get_template(
 
 #### template_id (required)
 
-The ID of the template. Sign into GOV.UK Notify and go to the __Templates__ page to find this. 
+The ID of the template. Sign into GOV.UK Notify and go to the __Templates__ page to find this.
 
 ### Response
 
@@ -768,7 +811,7 @@ response = notifications_client.get_template_version(
 
 #### template_id (required)
 
-The ID of the template. Sign in to GOV.UK Notify and go to the __Templates__ page to find this. 
+The ID of the template. Sign in to GOV.UK Notify and go to the __Templates__ page to find this.
 
 #### version (required)
 
@@ -946,7 +989,7 @@ If the request to the client is successful, the client will return a `<generator
 
 ## Get one page of received text messages
 
-This will return one page of up to 250 text messages.  
+This will return one page of up to 250 text messages.
 
 ### Method
 

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+import time
 import os
 import uuid
 
@@ -16,6 +18,7 @@ from integration_test.schemas.v2.templates_schemas import get_all_template_respo
 from integration_test.enums import SMS_TYPE, EMAIL_TYPE, LETTER_TYPE
 
 from notifications_python_client.notifications import NotificationsAPIClient
+from notifications_python_client.errors import HTTPError
 
 
 def validate(json_to_validate, schema):
@@ -105,6 +108,28 @@ def get_notification_by_id(python_client, id, notification_type):
         validate(response, get_notification_response)
     else:
         raise KeyError("notification type should be email|sms")
+
+
+def get_letter_pdf(python_client, id):
+    # this might fail if the pdf file hasn't been created/virus scanned yet, so check a few times.
+    count = 0
+    while True:
+        try:
+            response = python_client.get_letter_pdf(id)
+            break
+        except HTTPError as exc:
+            if exc.message[0]['error'] != 'PDFNotReadyError':
+                raise
+
+            count += 1
+            if count > 6:  # total time slept at this point is 21 seconds
+                print('pdf not ready after 21 seconds')
+                raise
+            else:
+                time.sleep(count)
+
+    assert type(response) == BytesIO
+    assert len(response.read()) != 0
 
 
 def get_received_text_messages():
@@ -230,6 +255,9 @@ def test_integration():
     get_all_templates(client)
     get_all_templates_for_type(client, EMAIL_TYPE)
     get_all_templates_for_type(client, SMS_TYPE)
+
+    get_letter_pdf(client, letter_id)
+    get_letter_pdf(client, precompiled_letter_id)
 
     if (os.environ['INBOUND_SMS_QUERY_KEY']):
         get_received_text_messages()

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -110,12 +110,12 @@ def get_notification_by_id(python_client, id, notification_type):
         raise KeyError("notification type should be email|sms")
 
 
-def get_letter_pdf(python_client, id):
+def get_pdf_for_letter(python_client, id):
     # this might fail if the pdf file hasn't been created/virus scanned yet, so check a few times.
     count = 0
     while True:
         try:
-            response = python_client.get_letter_pdf(id)
+            response = python_client.get_pdf_for_letter(id)
             break
         except HTTPError as exc:
             if exc.message[0]['error'] != 'PDFNotReadyError':
@@ -256,8 +256,8 @@ def test_integration():
     get_all_templates_for_type(client, EMAIL_TYPE)
     get_all_templates_for_type(client, SMS_TYPE)
 
-    get_letter_pdf(client, letter_id)
-    get_letter_pdf(client, precompiled_letter_id)
+    get_pdf_for_letter(client, letter_id)
+    get_pdf_for_letter(client, precompiled_letter_id)
 
     if (os.environ['INBOUND_SMS_QUERY_KEY']):
         get_received_text_messages()

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.3.0'
+__version__ = '5.4.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -7,6 +7,7 @@ standard_library.install_aliases()
 import base64
 import logging
 import re
+from io import BytesIO
 
 from notifications_python_client.base import BaseAPIClient
 
@@ -107,6 +108,15 @@ class NotificationsAPIClient(BaseAPIClient):
 
     def get_notification_by_id(self, id):
         return self.get('/v2/notifications/{}'.format(id))
+
+    def get_letter_pdf(self, id):
+        url = '/v2/notifications/{}/pdf'.format(id)
+        logger.debug("API request {} {}".format('GET', url))
+        url, kwargs = self._create_request_objects(url, data=None, params=None)
+
+        response = self._perform_request('GET', url, kwargs)
+
+        return BytesIO(response.content)
 
     def get_all_notifications(self, status=None, template_type=None, reference=None, older_than=None):
         data = {}

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -109,7 +109,7 @@ class NotificationsAPIClient(BaseAPIClient):
     def get_notification_by_id(self, id):
         return self.get('/v2/notifications/{}'.format(id))
 
-    def get_letter_pdf(self, id):
+    def get_pdf_for_letter(self, id):
         url = '/v2/notifications/{}/pdf'.format(id)
         logger.debug("API request {} {}".format('GET', url))
         url, kwargs = self._create_request_objects(url, data=None, params=None)

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.3.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.4.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -504,6 +504,21 @@ def test_get_all_templates_by_type(notifications_client, rmock):
     assert rmock.called
 
 
+def test_get_pdf_for_letter(notifications_client, rmock):
+    endpoint = "{0}/v2/notifications/{1}/pdf".format(TEST_HOST, "123")
+    rmock.request(
+        "GET",
+        endpoint,
+        content=b'foo',
+        status_code=200)
+
+    response = notifications_client.get_pdf_for_letter('123')
+
+    assert response.read() == b'foo'
+
+    assert rmock.called
+
+
 def _generate_response(next_link_uuid, notifications=[]):
     return {
         'json': {


### PR DESCRIPTION
Add new endpoint for get_letter_pdf (see https://github.com/alphagov/notifications-api/pull/2610). Still not sure whether we should make a new exception type (other than BadRequestError) for these specific errors, but I think this is okay as a first stab at it.

Content has been karlified

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
