### PR TITLE
Add `TokenAlgorithmError` for when algorithm is not HS256

### DIFF
--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.4.0'
+__version__ = '5.4.1'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -35,6 +35,11 @@ class TokenIssuedAtError(TokenDecodeError):
         super().__init__('Invalid token: iat field not provided')
 
 
+class TokenAlgorithmError(TokenDecodeError):
+    def __init__(self):
+        super().__init__('Invalid token: algorithm used is not HS256')
+
+
 class APIError(Exception):
     def __init__(self, response=None, message=None):
         self.response = response

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -15,7 +15,7 @@ from freezegun import freeze_time
 from notifications_python_client.authentication import (
     create_jwt_token, decode_jwt_token, get_token_issuer)
 from notifications_python_client.errors import (
-    TokenExpiredError, TokenDecodeError, TokenIssuerError, TokenIssuedAtError)
+    TokenExpiredError, TokenDecodeError, TokenIssuerError, TokenIssuedAtError, TokenAlgorithmError)
 
 
 # helper method to directly decode token
@@ -154,6 +154,18 @@ def test_decode_should_handle_invalid_token_with_missing_field(missing_field, ex
     )
 
     with pytest.raises(exc_class):
+        decode_jwt_token(token, 'bar')
+
+
+def test_decode_should_handle_invalid_token_with_non_hs256_algorithm():
+    payload = {'iss': '1234', 'iat': '1234'}
+    token = jwt.encode(
+        payload=payload,
+        key='bar',
+        headers={'typ': 'JWT', 'alg': 'HS512'}
+    )
+
+    with pytest.raises(TokenAlgorithmError):
         decode_jwt_token(token, 'bar')
 
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.4.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.4.1"


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
When we decrypt tokens we only allow HS256 so should raise an error rather then let the `jwt.exceptions.InvalidAlgorithmError` be uncaught.

Note, had to split up our main `decode_jwt_token` function because otherwise flake8 says it is too complex - pfffft!

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
