### PR TITLE
Catch generic JWT InvalidTokenErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.0
+
+* Improve error messages for errors related to JSON Web Tokens
+
 ## 5.4.0
 
 * Add `NotificationsAPIClient.get_pdf_for_letter(id)`

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.4.2'
+__version__ = '5.5.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.4.1'
+__version__ = '5.4.2'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -16,13 +16,18 @@ class TokenError(Exception):
         self.token = token
 
 
+class TokenExpiredError(TokenError):
+    pass
+
+
+class TokenAlgorithmError(TokenError):
+    def __init__(self):
+        super().__init__('Invalid token: algorithm used is not HS256')
+
+
 class TokenDecodeError(TokenError):
     def __init__(self, message=None):
         super().__init__(message or 'Invalid token: signature')
-
-
-class TokenExpiredError(TokenError):
-    pass
 
 
 class TokenIssuerError(TokenDecodeError):
@@ -33,11 +38,6 @@ class TokenIssuerError(TokenDecodeError):
 class TokenIssuedAtError(TokenDecodeError):
     def __init__(self):
         super().__init__('Invalid token: iat field not provided')
-
-
-class TokenAlgorithmError(TokenDecodeError):
-    def __init__(self):
-        super().__init__('Invalid token: algorithm used is not HS256')
 
 
 class APIError(Exception):

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -5,14 +5,17 @@ from __future__ import absolute_import
 from builtins import super
 from future import standard_library
 standard_library.install_aliases()
+
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Request failed"
+
+TOKEN_ERROR_GENERIC_MESSAGE = "Invalid token: See our requirements for JSON Web Tokens at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header"  # noqa
 
 
 class TokenError(Exception):
 
-    def __init__(self, message, token=None):
-        self.message = message
+    def __init__(self, message=None, token=None):
+        self.message = message if message else TOKEN_ERROR_GENERIC_MESSAGE
         self.token = token
 
 

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -9,13 +9,14 @@ standard_library.install_aliases()
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Request failed"
 
-TOKEN_ERROR_GENERIC_MESSAGE = "Invalid token: See our requirements for JSON Web Tokens at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header"  # noqa
+TOKEN_ERROR_GUIDANCE = "See our requirements for JSON Web Tokens at https://docs.notifications.service.gov.uk/rest-api.html#authorisation-header"  # noqa
+TOKEN_ERROR_DEFAULT_ERROR_MESSAGE = "Invalid token: " + TOKEN_ERROR_GUIDANCE
 
 
 class TokenError(Exception):
 
     def __init__(self, message=None, token=None):
-        self.message = message if message else TOKEN_ERROR_GENERIC_MESSAGE
+        self.message = message + ". " + TOKEN_ERROR_GUIDANCE if message else TOKEN_ERROR_DEFAULT_ERROR_MESSAGE
         self.token = token
 
 

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -57,7 +57,7 @@ def test_token_should_fail_to_decode_if_wrong_key():
     assert str(err.value) == "Signature verification failed"
 
 
-@pytest.mark.parametrize('exc_class', [
+@pytest.mark.parametrize('exception_class', [
     jwt.InvalidAudienceError,
     jwt.ImmatureSignatureError,
     jwt.InvalidIssuerError,
@@ -65,9 +65,9 @@ def test_token_should_fail_to_decode_if_wrong_key():
 
 ])
 @mock.patch('notifications_python_client.authentication.jwt.decode')
-def test_decode_jwt_token_raises_token_error_if_jwt_invalid_token_error_exception(decode_mock, exc_class):
+def test_decode_jwt_token_raises_token_error_if_jwt_invalid_token_error_exception(decode_mock, exception_class):
     token = create_jwt_token("key", "client_id")
-    decode_mock.side_effect = exc_class
+    decode_mock.side_effect = exception_class
 
     with pytest.raises(TokenError) as err:
         decode_jwt_token(token, "key")
@@ -170,11 +170,11 @@ def test_get_token_issuer_should_handle_invalid_token_with_no_iss():
     assert "Invalid token: iss field not provided. See our requirements" in e.value.message
 
 
-@pytest.mark.parametrize('missing_field,exc_class', [
+@pytest.mark.parametrize('missing_field,exception_class', [
     ('iss', TokenIssuerError),
     ('iat', TokenIssuedAtError),
 ])
-def test_decode_should_handle_invalid_token_with_missing_field(missing_field, exc_class):
+def test_decode_should_handle_invalid_token_with_missing_field(missing_field, exception_class):
     payload = {'iss': '1234', 'iat': '1234'}
     payload.pop(missing_field)
     token = jwt.encode(
@@ -183,7 +183,7 @@ def test_decode_should_handle_invalid_token_with_missing_field(missing_field, ex
         headers={'typ': 'JWT', 'alg': 'HS256'}
     )
 
-    with pytest.raises(exc_class):
+    with pytest.raises(exception_class):
         decode_jwt_token(token, 'bar')
 
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.4.1"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.4.2"

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.4.2"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.5.0"


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
- We are seeing niche tokens come in (for example users setting the `aud` claim) which fail validation by jwt and raise exceptions that we aren't explicitely catching. We want to catch these exceptions and so therefore we catch all `InvalidTokenError`s to cover invalid tokens that aren't being caught by our more specific errors.

## Questions
- Should all our errors to do with tokens also provide the link to the docs (on top of their more specific error message) as this seems generally useful?


## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
