### PR TITLE
Update tests and documentation so they handle postcode being validated

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -389,6 +389,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters with a team api key"`<br>`]}`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this notification in  [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation address_line_1 is a required property"`<br>`}]`|Ensure that your template has a field for the first line of the address, check [personalisation](#send-a-letter-arguments-personalisation-optional) for more information.|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "Must be a real UK postcode"`<br>`}]`|Ensure that the value for the postcode field in your letter is a real UK postcode|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct API key. Refer to [API keys](#api-keys) for more information|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 3000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](#rate-limits) for more information|

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -323,7 +323,7 @@ The personalisation argument always contains the following required parameters f
 
 - `address_line_1`
 - `address_line_2`
-- `postcode`
+- `postcode` (this needs to be a real UK postcode)
 
 Any other placeholder fields included in the letter template also count as required parameters. You need to provide their values in a dictionary with key value pairs. For example:
 
@@ -527,7 +527,7 @@ If the request to the client is successful, the client will return a `dict`:
   "line_4": "ADDRESS LINE 4", # optional string for letter
   "line_5": "ADDRESS LINE 5", # optional string for letter
   "line_6": "ADDRESS LINE 6", # optional string for letter
-  "postcode": "STRING", # required string for letter
+  "postcode": "A REAL UK POSTCODE", # required string for letter
   "type": "sms / letter / email", # required string
   "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure", # required string
   "template": {
@@ -678,7 +678,7 @@ If the request to the client is successful, the client returns a `dict`.
       "line_4": "ADDRESS LINE 4", # optional string for letter
       "line_5": "ADDRESS LINE 5", # optional string for letter
       "line_6": "ADDRESS LINE 6", # optional string for letter
-      "postcode": "STRING", # required for string letter
+      "postcode": "A REAL UK POSTCODE", # required string for letter
       "type": "sms / letter / email", # required string
       "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure", # required string
       "template": {

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -63,7 +63,7 @@ def send_letter_notification_test_response(python_client):
     personalisation = {
         'address_line_1': unique_name,
         'address_line_2': 'foo',
-        'postcode': 'bar'
+        'postcode': 'SW1 1AA'
     }
     response = python_client.send_letter_notification(
         template_id=template_id,

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -303,7 +303,7 @@ def test_create_letter_notification(notifications_client, rmock):
 
     notifications_client.send_letter_notification(
         template_id="456",
-        personalisation={'address_line_1': 'Foo', 'address_line_2': 'Bar', 'postcode': 'Baz'}
+        personalisation={'address_line_1': 'Foo', 'address_line_2': 'Bar', 'postcode': 'SW1 1AA'}
     )
 
     assert rmock.last_request.json() == {
@@ -311,7 +311,7 @@ def test_create_letter_notification(notifications_client, rmock):
         'personalisation': {
             'address_line_1': 'Foo',
             'address_line_2': 'Bar',
-            'postcode': 'Baz'
+            'postcode': 'SW1 1AA'
         }
     }
 
@@ -326,7 +326,7 @@ def test_create_letter_notification_with_reference(notifications_client, rmock):
 
     notifications_client.send_letter_notification(
         template_id="456",
-        personalisation={'address_line_1': 'Foo', 'address_line_2': 'Bar', 'postcode': 'Baz'},
+        personalisation={'address_line_1': 'Foo', 'address_line_2': 'Bar', 'postcode': 'SW1 1AA'},
         reference='Baz'
     )
 
@@ -335,7 +335,7 @@ def test_create_letter_notification_with_reference(notifications_client, rmock):
         'personalisation': {
             'address_line_1': 'Foo',
             'address_line_2': 'Bar',
-            'postcode': 'Baz'
+            'postcode': 'SW1 1AA'
         },
         'reference': 'Baz'
     }


### PR DESCRIPTION
This work is for this PR to work properly when deploying (otherwise client integrations tests will start failing): https://github.com/alphagov/notifications-api/pull/2751