### PR TITLE
Add is_csv kwarg to prepare_upload util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.6.0
+
+* Add support for an optional `is_csv` parameter in the `prepare_upload()` function. This fixes a bug when sending a CSV file by email. This ensures that the file is downloaded as a CSV rather than a TXT file.
+
 ## 5.5.1
 
 * change error message to refer to file rather than document

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -244,6 +244,23 @@ with open('file.pdf', 'rb') as f:
     }
 ```
 
+#### CSV Files
+
+Uploads for CSV files should use the `is_csv` parameter
+on the `prepare_upload()` utility.  For example:
+
+```python
+from notifications_python_client import prepare_upload
+
+with open('file.csv', 'rb') as f:
+    ...
+    personalisation={
+      'first_name': 'Amala',
+      'application_date': '2018-01-01',
+      'link_to_file': prepare_upload(f, is_csv=True),
+    }
+```
+
 ### Response
 
 If the request to the client is successful, the client returns a `dict`:

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.5.1'
+__version__ = '5.6.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/utils.py
+++ b/notifications_python_client/utils.py
@@ -3,12 +3,13 @@ import base64
 DOCUMENT_UPLOAD_SIZE_LIMIT = 2 * 1024 * 1024
 
 
-def prepare_upload(f):
+def prepare_upload(f, is_csv=False):
     contents = f.read()
 
     if len(contents) > DOCUMENT_UPLOAD_SIZE_LIMIT:
         raise ValueError('File is larger than 2MB')
 
     return {
-        'file': base64.b64encode(contents).decode('ascii')
+        'file': base64.b64encode(contents).decode('ascii'),
+        'is_csv': is_csv,
     }

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.5.1"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.6.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -263,7 +263,7 @@ def test_create_email_notification_with_document_stream_upload(notifications_cli
         'template_id': '456', 'email_address': 'to@example.com',
         'personalisation': {
             'name': 'chris',
-            'doc': {'file': 'ZmlsZS1jb250ZW50cw=='}
+            'doc': {'file': 'ZmlsZS1jb250ZW50cw==', 'is_csv': False}
         }
     }
 
@@ -288,7 +288,32 @@ def test_create_email_notification_with_document_file_upload(notifications_clien
         'template_id': '456', 'email_address': 'to@example.com',
         'personalisation': {
             'name': 'chris',
-            'doc': {'file': 'JVBERi0xLjUgdGVzdAo='}
+            'doc': {'file': 'JVBERi0xLjUgdGVzdAo=', 'is_csv': False}
+        }
+    }
+
+
+def test_create_email_notification_with_csv_file_upload(notifications_client, rmock):
+    endpoint = "{0}/v2/notifications/email".format(TEST_HOST)
+    rmock.request(
+        "POST",
+        endpoint,
+        json={"status": "success"},
+        status_code=200)
+
+    with open('tests/test_files/test.csv', 'rb') as f:
+        notifications_client.send_email_notification(
+            email_address="to@example.com", template_id="456", personalisation={
+                'name': 'chris',
+                'doc': prepare_upload(f, is_csv=True)
+            }
+        )
+
+    assert rmock.last_request.json() == {
+        'template_id': '456', 'email_address': 'to@example.com',
+        'personalisation': {
+            'name': 'chris',
+            'doc': {'file': 'VGhpcyBpcyBhIGNzdiwK', 'is_csv': True}
         }
     }
 

--- a/tests/notifications_python_client/test_utils.py
+++ b/tests/notifications_python_client/test_utils.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import pytest
 
@@ -9,3 +10,18 @@ def test_prepare_upload_raises_an_error_for_large_files():
         prepare_upload(io.BytesIO(b'a' * 3 * 1024 * 1024))
 
     assert 'larger than 2MB' in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    'is_csv',
+    (
+        True,
+        False,
+    )
+)
+def test_prepare_upload_generates_expected_dict(is_csv):
+    file_content = b'a' * 256
+    file_dict = prepare_upload(io.BytesIO(file_content), is_csv=is_csv)
+
+    assert file_dict['is_csv'] == is_csv
+    assert file_dict['file'] == base64.b64encode(file_content).decode('ascii')

--- a/tests/test_files/test.csv
+++ b/tests/test_files/test.csv
@@ -1,0 +1,1 @@
+This is a csv,


### PR DESCRIPTION
## What problem does the pull request solve?

This PR adds an optional `is_csv` parameter to the `prepare_upload()` utility to allow clients to explicitly specify that the file they are uploading is a CSV. This provides a fix for an issue where uploads could not be saved as CSV and would always be saved as TXT. For more info, refer to: alphagov/notifications-python-client#164

## Checklist

- [x] I’ve used the pull request template
- [X] I’ve written unit tests for these changes
- [X] I’ve update the documentation in
  - [X] `DOCUMENTATION.md`
  - [X] `CHANGELOG.md`
- [X] I’ve bumped the version number in
  - [X] `notifications_python_client/__init__.py`
  - [X] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`