### PR TITLE
Update status tables

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -481,21 +481,25 @@ Message status depends on the type of message you have sent.
 
 You can only get the status of messages that are 7 days old or newer.
 
-## Status - text and email
+## Status - email
 
 |Status|Information|
 |:---|:---|
 |Created|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
 |Sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
 |Delivered|The message was successfully delivered.|
-|Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address or phone number was wrong. You should remove these email addresses or phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full or their phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
+|Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again."|
 
-## Status - text only
+## Status - text message
 
 |Status|Information|
 |:---|:---|
-|Pending|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient's device has not yet responded. Another callback from the provider determines the final status of the notification.|
+|Created|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
+|Sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
+|Pending|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the notification.|
 |Sent / Sent internationally|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify client API returns this status as `sent`. The GOV.UK Notify client app returns this status as `Sent internationally`.|
+|Delivered|The message was successfully delivered.|
+|Failed|This covers all failure statuses:<br>- `permanent-failure` - "The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered."<br>- `temporary-failure` - "The provider could not deliver the message. This can happen when the recipient’s phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages."<br>- `technical-failure` - "Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure."|
 
 ## Status - letter
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -643,22 +643,14 @@ You can filter by:
 
 #### status (optional)
 
-| status | description | text | email | letter |Precompiled letter|
-|:--- |:--- |:--- |:--- |:--- |:--- |
-|created|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|Yes|Yes|||
-|sending|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|Yes|Yes|||
-|delivered|The message was successfully delivered|Yes|Yes|||
-|sent / sent internationally|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information.|Yes||||
-|pending|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient's device has not yet responded. Another callback from the provider determines the final status of the notification.|Yes||||
-|failed|This returns all failure statuses:<br>- permanent-failure<br>- temporary-failure<br>- technical-failure|Yes|Yes|||
-|permanent-failure|The provider could not deliver the message because the email address or phone number was wrong. You should remove these email addresses or phone numbers from your database. You’ll still be charged for text messages to numbers that do not exist.|Yes|Yes|||
-|temporary-failure|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their phone is off. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|Yes|Yes|||
-|technical-failure|Email / Text: Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure. <br><br>Letter: Notify had an unexpected error while sending to our printing provider. <br><br>You can leave out this argument to ignore this filter.|Yes|Yes|||
-|accepted|GOV.UK Notify has sent the letter to the provider to be printed.|||Yes||
-|received|The provider has printed and dispatched the letter.|||Yes||
-|pending-virus-check|GOV.UK Notify is scanning the precompiled letter file for viruses.||||Yes|
-|virus-scan-failed|GOV.UK Notify found a potential virus in the precompiled letter file.||||Yes|
-|validation-failed|Content in the precompiled letter file is outside the printable area.||||Yes|
+You can filter by each:
+
+* [email status](#status---email)
+* [text message status](#status---text-message)
+* [letter status](#status---letter)
+* [precompiled letter status](#status---precompiled-letter)
+
+You can leave out this argument to ignore this filter.
 
 #### reference (optional)
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -645,10 +645,10 @@ You can filter by:
 
 You can filter by each:
 
-* [email status](#status---email)
-* [text message status](#status---text-message)
-* [letter status](#status---letter)
-* [precompiled letter status](#status---precompiled-letter)
+* [email status](#status-email)
+* [text message status](#status-text-message)
+* [letter status](#status-letter)
+* [precompiled letter status](#status-precompiled-letter)
 
 You can leave out this argument to ignore this filter.
 


### PR DESCRIPTION
This PR updates the status description tables so that:

* there's a separate table for emails and text messages
* all text message statuses are grouped together
* the `permanent failure` text message status is consistent with the Notify status page

It also replaces the extra status table under 'Get the status of multiple messages' with links to the other status tables.