### PR TITLE
Rename whitelist to guest list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ SMS_TEMPLATE_ID "valid sms_template_id"
 LETTER_TEMPLATE_ID "valid letter_template_id"
 EMAIL_REPLY_TO_ID "valid email reply to id"
 SMS_SENDER_ID "valid sms_sender_id - to test sending to a receiving number, so needs to be a valid number"
-API_SENDING_KEY "API_whitelist_key for sending an SMS to a receiving number"
+API_SENDING_KEY "API_team_key for sending an SMS to a receiving number"
 INBOUND_SMS_QUERY_KEY "API_test_key to get received text messages - leave blank for local development as cannot test locally"
 ```
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -121,7 +121,7 @@ If the request to the client is successful, the client returns a `dict`:
 
 If you are using the [test API key](#test), all your messages will come back with a `delivered` status.
 
-All messages sent using the [team and whitelist](#team-and-whitelist) or [live](#live) keys will appear on your dashboard.
+All messages sent using the [team and guest list](#team-and-guest-list) or [live](#live) keys will appear on your dashboard.
 
 ### Error codes
 

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -211,7 +211,7 @@ def test_integration():
         base_url=os.environ['NOTIFY_API_URL'],
         api_key=os.environ['API_KEY']
     )
-    client_using_whitelist_key = NotificationsAPIClient(
+    client_using_team_key = NotificationsAPIClient(
         base_url=os.environ['NOTIFY_API_URL'],
         api_key=os.environ['API_SENDING_KEY']
     )
@@ -229,7 +229,7 @@ def test_integration():
     version_number = 1
 
     sms_id = send_sms_notification_test_response(client)
-    sms_with_sender_id = send_sms_notification_test_response(client_using_whitelist_key, sms_sender_id)
+    sms_with_sender_id = send_sms_notification_test_response(client_using_team_key, sms_sender_id)
     email_id = send_email_notification_test_response(client)
     email_with_reply_id = send_email_notification_test_response(client, email_reply_to_id)
     letter_id = send_letter_notification_test_response(client)


### PR DESCRIPTION
We’re renaming the ‘Team and whitelist’ key in https://github.com/alphagov/notifications-admin/pull/3479

This commit updates the documentation to match.
