### PR TITLE
Fix parsing of errors from Notify REST API

### DIFF
--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.7.0'
+__version__ = '5.8.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -50,7 +50,21 @@ class APIError(Exception):
         self._message = message
 
     def __str__(self):
-        return "{} - {}".format(self.status_code, self.message)
+        return "{} - {}".format(self.status_code, self.error_message)
+
+    @property
+    def errors(self):
+        try:
+            return self.response.json().get('errors', [self.response.json()])
+        except (TypeError, ValueError, AttributeError, KeyError):
+            return [{'message': self._message or REQUEST_ERROR_MESSAGE}]
+
+    @property
+    def error_message(self):
+        try:
+            return self.response.json()['errors'][0]['message']
+        except (TypeError, ValueError, AttributeError, IndexError, KeyError):
+            return self.message
 
     @property
     def message(self):

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -82,6 +82,31 @@ def test_non_2xx_response_raises_api_error(base_client, rmock):
     assert e.value.status_code == 404
 
 
+def test_exception_parses_errors_response(rmock, base_client):
+    """Test parsing of error response"""
+    rmock.request(
+        "GET",
+        "http://test-host",
+        json={
+            "errors": [{
+                "error": "AuthError",
+                "message": "Unauthorized: authentication token must be provided"
+            }],
+            "status_code": 401
+        },
+        status_code=401
+    )
+
+    with pytest.raises(HTTPError) as e:
+        base_client.request("GET", "/")
+
+    assert str(e.value) == "401 - Unauthorized: authentication token must be provided"
+    assert e.value.errors == [{"error": "AuthError", "message": "Unauthorized: authentication token must be provided"}]
+    assert e.value.message == [{"error": "AuthError", "message": "Unauthorized: authentication token must be provided"}]
+    assert e.value.error_message == "Unauthorized: authentication token must be provided"
+    assert e.value.status_code == 401
+
+
 def test_invalid_json_raises_api_error(base_client, rmock):
     rmock.request(
         "GET",

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -142,4 +142,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.7.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.8.0"

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -71,7 +71,7 @@ def test_non_2xx_response_raises_api_error(base_client, rmock):
     rmock.request(
         "GET",
         "http://test-host/",
-        json={"errors": "Not found"},
+        json={"message": "Not found"},
         status_code=404)
 
     with pytest.raises(HTTPError) as e:

--- a/tests/notifications_python_client/test_errors.py
+++ b/tests/notifications_python_client/test_errors.py
@@ -1,0 +1,64 @@
+import mock
+
+import pytest
+
+from notifications_python_client.errors import HTTPError
+
+
+@pytest.fixture
+def make_mock_response():
+    def factory(*, json, status_code):
+        response = mock.Mock()
+        response.json.return_value = json
+        response.status_code = status_code
+        return response
+
+    return factory
+
+
+@pytest.mark.parametrize('json, errors', (
+    (
+        {'errors': [{'error': 'AuthError', 'message': 'Invalid token: API key not found'}]},
+        [{'error': 'AuthError', 'message': 'Invalid token: API key not found'}]
+    ),
+    (
+        {'message': 'The requested URL was not found on the server'},
+        [{'message': 'The requested URL was not found on the server'}]
+    ),
+    (
+        None,
+        [{'message': 'Request failed'}]
+    )
+))
+def test_errors_is_list_of_objects(make_mock_response, json, errors):
+    error = HTTPError(response=make_mock_response(
+        json=json,
+        status_code=400,
+    ))
+
+    assert len(error.errors)
+    assert error.errors == errors
+
+
+@pytest.mark.parametrize('json, error_message', (
+    (
+        {'errors': [{'error': 'AuthError', 'message': 'Invalid token: API key not found'}]},
+        'Invalid token: API key not found'
+    ),
+    (
+        {'message': 'The requested URL was not found on the server'},
+        'The requested URL was not found on the server'
+    ),
+    (
+        None,
+        'Request failed'
+    ),
+))
+def test_error_message_is_a_string(make_mock_response, json, error_message):
+    error = HTTPError(response=make_mock_response(
+        json=json,
+        status_code=400,
+    ))
+
+    assert isinstance(error.error_message, str)
+    assert error.error_message == error_message


### PR DESCRIPTION
## What problem does the pull request solve?

Currently the notifications client HTTPError exception will return the `errors` object for errors that look like those documented in https://docs.notifications.service.gov.uk/rest-api.html#error-codes.

This isn't what I was expecting, and seems like a bug to me, for two reasons:

1. the `str()` value will include the JSON in a way that looks ugly
2. the type of `error` will change depending on the format of the HTTP
response (it can be a string or a list of dicts)

This commit tries to fix this in a backwards-compatible way, by adding two new properties, `errors` that always returns a list of dicts, and `error_message` that always returns a `str`. `str()` of a HTTPError will now always just include the error message, rather than the whole error JSON object.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`