### PR TITLE
Update link and link text for accessibility

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -436,7 +436,7 @@ A unique identifier you create. This reference identifies a single unique precom
 
 ##### pdf_file (required)
 
-The precompiled letter must be a PDF file which meets [the GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf).
+The precompiled letter must be a PDF file which meets [the GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification).
 
 ```python
 with open("path/to/pdf_file", "rb") as pdf_file:
@@ -751,7 +751,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |:---|:---|
 |`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify PDF letter specification](https://docs.notifications.service.gov.uk/documentation/images/notify-pdf-letter-spec-v2.4.pdf) for more information.|
+|`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
 |`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
 |`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |`received`|The provider has printed and dispatched the letter.|


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
Updates the link and link text so users go to the new 'Letter specification' page, instead of the PDF.

We're doing this because of the work done in: https://github.com/alphagov/notifications-admin/pull/3624

This is part of our accessibility compliance work.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
