### PR TITLE
Support PyJWT 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.7.1
+* Support PyJWT 2.0 
+
 ## 5.7.0
 
 * We added `letter_contact_block` to our template object serialization, which means it will be added to responses for `get_template_by_id` requests and also `get_template_version` and `get_all_templates` . This version adds this new `letter_contact_block` attribute to Documentation and tests.  

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '5.7.0'
+__version__ = '5.7.1'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/authentication.py
+++ b/notifications_python_client/authentication.py
@@ -54,8 +54,11 @@ def create_jwt_token(secret, client_id):
         'iss': client_id,
         'iat': epoch_seconds()
     }
-
-    return jwt.encode(payload=claims, key=secret, headers=headers).decode()
+    t = jwt.encode(payload=claims, key=secret, headers=headers)
+    if isinstance(t, str):
+        return t
+    else:
+        return t.decode()
 
 
 def get_token_issuer(token):

--- a/notifications_python_client/authentication.py
+++ b/notifications_python_client/authentication.py
@@ -103,8 +103,8 @@ def decode_jwt_token(token, secret):
         # check signature of the token
         decoded_token = jwt.decode(
             token,
-            key=secret.encode(),
-            verify=True,
+            key=secret,
+            options={"verify_signature": True},
             algorithms=[__algorithm__],
             leeway=__bound__
         )
@@ -149,7 +149,7 @@ def decode_token(token):
     :param token:
     :return decoded token:
     """
-    return jwt.decode(token, verify=False, algorithms=[__algorithm__])
+    return jwt.decode(token, options={"verify_signature": False}, algorithms=[__algorithm__])
 
 
 def epoch_seconds():

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -28,7 +28,7 @@ from notifications_python_client.errors import (
 
 # helper method to directly decode token
 def decode_token(token, secret):
-    return jwt.decode(token, key=secret, verify=True, algorithms=['HS256'])
+    return jwt.decode(token, key=secret, options={"verify_signature": True}, algorithms=['HS256'])
 
 
 def test_should_reject_token_request_if_missing_secret():
@@ -175,7 +175,7 @@ def test_get_token_issuer_should_handle_invalid_token_with_no_iss():
     ('iat', TokenIssuedAtError),
 ])
 def test_decode_should_handle_invalid_token_with_missing_field(missing_field, exception_class):
-    payload = {'iss': '1234', 'iat': '1234'}
+    payload = {'iss': '1234', 'iat': calendar.timegm(time.gmtime())}
     payload.pop(missing_field)
     token = jwt.encode(
         payload=payload,
@@ -188,7 +188,7 @@ def test_decode_should_handle_invalid_token_with_missing_field(missing_field, ex
 
 
 def test_decode_should_handle_invalid_token_with_non_hs256_algorithm():
-    payload = {'iss': '1234', 'iat': '1234'}
+    payload = {'iss': '1234', 'iat': calendar.timegm(time.gmtime())}
     token = jwt.encode(
         payload=payload,
         key='bar',

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -28,7 +28,7 @@ from notifications_python_client.errors import (
 
 # helper method to directly decode token
 def decode_token(token, secret):
-    return jwt.decode(token, key=secret.encode(), verify=True, algorithms=['HS256'])
+    return jwt.decode(token, key=secret, verify=True, algorithms=['HS256'])
 
 
 def test_should_reject_token_request_if_missing_secret():
@@ -162,7 +162,7 @@ def test_get_token_issuer_should_handle_invalid_token_with_no_iss():
         payload={'iat': 1234},
         key='1234',
         headers={'typ': 'JWT', 'alg': 'HS256'}
-    ).decode()
+    )
 
     with pytest.raises(TokenIssuerError) as e:
         get_token_issuer(token)

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.7.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/5.7.1"


### PR DESCRIPTION
The latest version of PyJWT returns a string when encoding the token rather than bytes. This handles for either version of the jwt.encode method.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ x] I’ve written unit tests for these changes
- [x ] I’ve update the documentation in
  - [x ] `DOCUMENTATION.md`
  - [ x] `CHANGELOG.md`
- [ x] I’ve bumped the version number in
  - [ x] `notifications_python_client/__init__.py`
  - [ x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ x] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
