### PR TITLE
use python_requires to stop pip installing on old py versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+* Properly block old versions of python from installing the new version
+
 ## 6.0.0
 
 * Removed support for old versions of python.

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -15,7 +15,7 @@ standard_library.install_aliases()
 #
 # -- http://semver.org/
 
-__version__ = '6.0.0'
+__version__ = '6.0.1'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
 
+    # only support actively patched versions of python (https://devguide.python.org/devcycle/#end-of-life-branches)
+    python_requires='>=3.6',
+
     install_requires=[
         'requests>=2.0.0',
         'PyJWT>=1.5.1',

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -117,4 +117,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.0.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.0.1"


### PR DESCRIPTION
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

set to >=3.6. note this is only respected by pip >= 9 so really old
setups will still be able to install old versions, but on their head
be it

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
