### PR TITLE
Delete deprecated dependencies

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
 # W503: line break before binary operator
-# E402: module level import not at top of file (because of future imports)
 exclude = venv*,__pycache__,node_modules,cache,migrations,build,.eggs,.tox,.pytest_cache,.cache
 ignore = W503,E402
 max-complexity = 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2
+
+* Remove two dependencies that are now not needed, `monotonic` and `future`
+
 ## 6.0.1
 
 * Properly block old versions of python from installing the new version

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.0.1'
+__version__ = '6.0.2'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -1,11 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from __future__ import print_function
-
-from future import standard_library
-standard_library.install_aliases()
-
 # Version numbering follows Semantic Versionning:
 #
 # Given a version number MAJOR.MINOR.PATCH, increment the:

--- a/notifications_python_client/authentication.py
+++ b/notifications_python_client/authentication.py
@@ -1,10 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import int
-from future import standard_library
-standard_library.install_aliases()
 import calendar
 import time
 

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -1,8 +1,8 @@
 import urllib.parse
 import logging
 import json
+import time
 
-from monotonic import monotonic
 import requests
 
 from notifications_python_client import __version__
@@ -84,7 +84,7 @@ class BaseAPIClient(object):
         return url, kwargs
 
     def _perform_request(self, method, url, kwargs):
-        start_time = monotonic()
+        start_time = time.monotonic()
         try:
             response = requests.request(
                 method,
@@ -105,7 +105,7 @@ class BaseAPIClient(object):
             )
             raise api_error
         finally:
-            elapsed_time = monotonic() - start_time
+            elapsed_time = time.monotonic() - start_time
             logger.debug("API {} request on {} finished in {}".format(method, url, elapsed_time))
 
     def _process_json_response(self, response):

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -1,9 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
 import urllib.parse
 import logging
 import json

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -1,11 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import super
-from future import standard_library
-standard_library.install_aliases()
-
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Request failed"
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import base64
 import logging
 import re

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'requests>=2.0.0',
         'PyJWT>=1.5.1',
         'docopt>=0.3.0',
-        'monotonic>=0.1',
     ],
     # for running pytest as `python setup.py test`, see
     # http://doc.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         'PyJWT>=1.5.1',
         'docopt>=0.3.0',
         'monotonic>=0.1',
-        'future',
     ],
     # for running pytest as `python setup.py test`, see
     # http://doc.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,25 +13,25 @@ API_KEY_ID = '8b3aa916-ec82-434e-b0c5-d5d9b371d6a3'
 COMBINED_API_KEY = 'key_name-{}-{}'.format(SERVICE_ID, API_KEY_ID)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def rmock():
     with requests_mock.mock() as rmock:
         yield rmock
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def rmock_patch():
     with mock.patch('notifications_python_client.base.requests.request') as rmock_patch:
         yield rmock_patch
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def base_client():
     yield BaseAPIClient(base_url=TEST_HOST,
                         api_key=COMBINED_API_KEY)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def notifications_client():
     yield NotificationsAPIClient(base_url=TEST_HOST,
                                  api_key=COMBINED_API_KEY)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 import mock
 
 import requests_mock

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -1,10 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
-from future import standard_library
-standard_library.install_aliases()
 import calendar
 import time
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -110,4 +110,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.0.1"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.0.2"

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -1,11 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from builtins import str
-from future import standard_library
-standard_library.install_aliases()
 import requests
 import mock
 

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -1,12 +1,6 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import base64
 import io
-from future import standard_library
 from mock import Mock
-standard_library.install_aliases()
 from tests.conftest import TEST_HOST
 
 from notifications_python_client import prepare_upload


### PR DESCRIPTION
Removed two dependencies that are not needed any more - `future` and `monotonic`. See commits for details.
