### PR TITLE
Add type hints to the errors module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.0
+
+* Add type hints for errors
+
 ## 6.0.2
 
 * Remove two dependencies that are now not needed, `monotonic` and `future`

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include Makefile  *.txt *.md
 recursive-include *.py
+include notifications_python_client/py.typed

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.0.2'
+__version__ = '6.1.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -1,3 +1,6 @@
+from requests import RequestException, Response
+from typing import List, Union
+
 REQUEST_ERROR_STATUS_CODE = 503
 REQUEST_ERROR_MESSAGE = "Request failed"
 
@@ -37,7 +40,7 @@ class TokenIssuedAtError(TokenDecodeError):
 
 
 class APIError(Exception):
-    def __init__(self, response=None, message=None):
+    def __init__(self, response: Response = None, message: str = None):
         self.response = response
         self._message = message
 
@@ -45,14 +48,14 @@ class APIError(Exception):
         return "{} - {}".format(self.status_code, self.message)
 
     @property
-    def message(self):
+    def message(self) -> Union[str, List[dict]]:
         try:
             return self.response.json().get('message', self.response.json().get('errors'))
         except (TypeError, ValueError, AttributeError, KeyError):
             return self._message or REQUEST_ERROR_MESSAGE
 
     @property
-    def status_code(self):
+    def status_code(self) -> int:
         try:
             return self.response.status_code
         except AttributeError:
@@ -61,7 +64,7 @@ class APIError(Exception):
 
 class HTTPError(APIError):
     @staticmethod
-    def create(e):
+    def create(e: RequestException) -> 'HTTPError':
         error = HTTPError(e.response)
         if error.status_code == 503:
             error = HTTP503Error(e.response)

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -50,14 +50,15 @@ class APIError(Exception):
     @property
     def message(self) -> Union[str, List[dict]]:
         try:
-            return self.response.json().get('message', self.response.json().get('errors'))
+            json_resp = self.response.json() # type: ignore
+            return json_resp.get('message', json_resp.get('errors'))
         except (TypeError, ValueError, AttributeError, KeyError):
             return self._message or REQUEST_ERROR_MESSAGE
 
     @property
     def status_code(self) -> int:
         try:
-            return self.response.status_code
+            return self.response.status_code # type: ignore
         except AttributeError:
             return REQUEST_ERROR_STATUS_CODE
 

--- a/notifications_python_client/errors.py
+++ b/notifications_python_client/errors.py
@@ -50,7 +50,7 @@ class APIError(Exception):
     @property
     def message(self) -> Union[str, List[dict]]:
         try:
-            json_resp = self.response.json() # type: ignore
+            json_resp = self.response.json()  # type: ignore
             return json_resp.get('message', json_resp.get('errors'))
         except (TypeError, ValueError, AttributeError, KeyError):
             return self._message or REQUEST_ERROR_MESSAGE
@@ -58,7 +58,7 @@ class APIError(Exception):
     @property
     def status_code(self) -> int:
         try:
-            return self.response.status_code # type: ignore
+            return self.response.status_code  # type: ignore
         except AttributeError:
             return REQUEST_ERROR_STATUS_CODE
 

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -110,4 +110,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.0.2"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.1.0"


### PR DESCRIPTION
## What problem does the pull request solve?

The return type of `APIError.message` can [surprise users](https://github.com/alphagov/notifications-python-client/pull/172). By adding a type hint, we can make it more likely that users notice and handle it correctly.

Now that we have [dropped Python 2.7 support](https://github.com/alphagov/notifications-python-client/pull/185), Python 3.6 is the oldest Python version we support. So we are safe to start using Python 3.6 features, including type hints. Start with the errors module, because it's reasonably small.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
~- [ ] I’ve written unit tests for these changes~
~- [ ] I’ve update the documentation in~
  ~- [ ] `DOCUMENTATION.md`~
  ~- [ ] `CHANGELOG.md`~
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
~- [ ] I've added new environment variables to~
  ~- [ ] `notifications-python-client/scripts/generate_docker_env.sh`~
  ~- [ ] `notifications-python-client/tox.ini`~
  ~- [ ] `CONTRIBUTING.md`~
