### PR TITLE
Add column heading markup to tables

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -716,46 +716,46 @@ If the request is not successful, the client returns an `HTTPError` containing t
 
 |Status|Description|
 |:---|:---|
-|`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|`delivered`|The message was successfully delivered.|
-|`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again.|
-|`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
+|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
+|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
+|#`delivered`|The message was successfully delivered.|
+|#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
+|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again.|
+|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
 
 ### Text message status descriptions
 
 |Status|Description|
 |:---|:---|
-|`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
-|`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
-|`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
-|`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
-|`delivered`|The message was successfully delivered.|
-|`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
-|`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
-|`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
+|#`created`|GOV.UK Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
+|#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
+|#`pending`|GOV.UK Notify is waiting for more delivery information.<br>GOV.UK Notify received a callback from the provider but the recipient’s device has not yet responded. Another callback from the provider determines the final status of the text message.|
+|#`sent`|The message was sent to an international number. The mobile networks in some countries do not provide any more delivery information. The GOV.UK Notify website displays this status as 'Sent to an international number'.|
+|#`delivered`|The message was successfully delivered.|
+|#`permanent-failure`|The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message. If you’re sure that these phone numbers are correct, you should [contact GOV.UK Notify support](https://www.notifications.service.gov.uk/support). If not, you should remove them from your database. You’ll still be charged for text messages that cannot be delivered.
+|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full. You can try to send the message again. You’ll still be charged for text messages to phones that are not accepting messages.|
+|#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again. You will not be charged for text messages that are affected by a technical failure.|
 
 ### Letter status descriptions
 
 |Status|Description|
 |:---|:---|
-|`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|`received`|The provider has printed and dispatched the letter.|
-|`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
+|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
+|#`received`|The provider has printed and dispatched the letter.|
+|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 
 ### Precompiled letter status descriptions
 
 |Status|Description|
 |:---|:---|
-|`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
-|`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
-|`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|`received`|The provider has printed and dispatched the letter.|
-|`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
+|#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
+|#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
+|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
+|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
+|#`received`|The provider has printed and dispatched the letter.|
+|#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 
 ### Get a PDF for a letter
 


### PR DESCRIPTION
Adding `#` before the content inside the first cell of each row in
a table changes the html from `<td>` to `<th scope="row">` when
using version 2.2.0 or later of the tech docs.

We need this on some tables to make them more accessible.
