### PR TITLE
Update email status description

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -720,7 +720,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |#`sending`|GOV.UK Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GOV.UK Notify is waiting for delivery information.|
 |#`delivered`|The message was successfully delivered.|
 |#`permanent-failure`|The provider could not deliver the message because the email address was wrong. You should remove these email addresses from your database.|
-|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full. You can try to send the message again.|
+|#`temporary-failure`|The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. [Check your content does not look like spam](https://www.gov.uk/service-manual/design/sending-emails-and-text-messages#protect-your-users-from-spam-and-phishing) before you try to send the message again.|
 |#`technical-failure`|Your message was not sent because there was a problem between Notify and the provider.<br>You’ll have to try sending your messages again.|
 
 ### Text message status descriptions


### PR DESCRIPTION
<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
This PR updates the ‘Inbox not accepting messages right now’ email status description.

We’re making this change because a full inbox is not the only reason a user might get this status.

We’ve added the link to Service manual content because we should help users to understand why their content might be triggering a recipient’s spam filter.

The Service manual content could probably do with updating, but I’ll tackle this as a separate piece of work.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
