### PR TITLE
Add permanent-failure status for letters.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -746,6 +746,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Precompiled letter status descriptions
 
@@ -758,6 +759,7 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`received`|The provider has printed and dispatched the letter.|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
+|#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
 ### Get a PDF for a letter
 


### PR DESCRIPTION
If a letter passes our validation but the print provider can not print the letter we should mark it as permanent-failure. An error message for permanent-failure is being added to the UI.
Technical-failure had the wrong message and validation failure will not show the pdf because the letter is in the wrong bucket.
