### PR TITLE
Optionally include notifications from jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+
+* Optionally include job notifications in `get_all_notifications`
+
 ## 6.1.0
 
 * Add type hints for errors

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -565,7 +565,7 @@ You can only get the status of messages sent within the retention period. The de
 This will return all your messages with statuses. They will display in pages of up to 250 messages each.
 
 ```python
-response = notifications_client.get_all_notifications(template_type, status, reference, older_than)
+response = notifications_client.get_all_notifications(template_type, status, reference, older_than, include_jobs)
 ```
 
 You can filter the returned messages by including the following optional arguments in the method:
@@ -574,6 +574,7 @@ You can filter the returned messages by including the following optional argumen
 - [`status`](#status-optional)
 - [`reference`](#get-the-status-of-multiple-messages-arguments-reference-optional)
 - [`older_than`](#older-than-optional)
+- [`include_jobs`](#include-jobs)
 
 
 ##### One page of up to 250 messages
@@ -647,6 +648,12 @@ older_than='740e5834-3a29-46b4-9a6f-16142fde533a' # optional string - notificati
 If you leave out this argument, the method returns the most recent 250 messages.
 
 The client only returns messages sent within the retention period. The default retention period is 7 days. If the message specified in this argument was sent before the retention period, the client returns an empty response.
+
+##### incude_jobs (optional)
+
+Includes notifications sent as part of a batch upload.
+
+If you leave out this argument, the method only returns notifications sent using the API.
 
 #### Response
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.1.0'
+__version__ = '6.2.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -112,7 +112,14 @@ class NotificationsAPIClient(BaseAPIClient):
 
         return BytesIO(response.content)
 
-    def get_all_notifications(self, status=None, template_type=None, reference=None, older_than=None):
+    def get_all_notifications(
+        self,
+        status=None,
+        template_type=None,
+        reference=None,
+        older_than=None,
+        include_jobs=None
+    ):
         data = {}
         if status:
             data.update({'status': status})
@@ -122,6 +129,8 @@ class NotificationsAPIClient(BaseAPIClient):
             data.update({'reference': reference})
         if older_than:
             data.update({'older_than': older_than})
+        if include_jobs:
+            data.update({'include_jobs': include_jobs})
         return self.get(
             '/v2/notifications',
             params=data

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -110,4 +110,4 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.1.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.2.0"

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -120,6 +120,19 @@ def test_get_all_notifications_by_status(notifications_client, rmock):
     assert rmock.called
 
 
+def test_get_all_notifications_including_jobs(notifications_client, rmock):
+    endpoint = "{0}/v2/notifications?include_jobs={1}".format(TEST_HOST, "true")
+    rmock.request(
+        "GET",
+        endpoint,
+        json={"status": "success"},
+        status_code=200)
+
+    notifications_client.get_all_notifications(include_jobs=True)
+
+    assert rmock.called
+
+
 def test_get_all_notifications(notifications_client, rmock):
     endpoint = "{0}/v2/notifications".format(TEST_HOST)
     rmock.request(


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4590242

Previously we would exclude these. We have a service [1] that:

- Uses the API to send initially.
- Uses the API to query failures.
- Uses the UI to manually resend.
- Uses the API to check the results.

While I'm not entirely convinced the last step is necessary, it
_is_ confhsing that what's visible in the UI is inconsistent with
the result from the API client. So, for at least that reason, this
adds the option to include notifications sent via a job.

Note that our Ruby client implicitly allows this already, by not
restricting the set of allowed parameters [2].

[1]: 53be32cd-69c1-4a72-a2e8-46ad8f768c61
[2]: https://github.com/alphagov/notifications-ruby-client/blob/328362a2df82cc0cb142618065467a032416cbd3/lib/notifications/client.rb#L101


<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
  - [x] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`

Separately:

- [ ] Let the user on the ticket know the change is being shipped.