### PR TITLE
Align status descriptions for all client documentation.

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -700,10 +700,10 @@ If the request to the client is successful, the client returns a `dict`.
 
 For more information, see the:
 
-* [email status descriptions](#email-status-descriptions)
-* [text message status descriptions](#text-message-status-descriptions)
-* [letter status descriptions](#letter-status-descriptions)
-* [precompiled letter status descriptions](#precompiled-letter-status-descriptions)
+* [email status](#email-status-descriptions)
+* [text message status](#text-message-status-descriptions)
+* [letter status](#letter-status-descriptions)
+* [precompiled letter status](#precompiled-letter-status-descriptions)
 
 #### Error codes
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -743,8 +743,8 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |Status|Description|
 |:---|:---|
 |#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`received`|The provider has printed and dispatched the letter.|
+|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 
@@ -752,12 +752,12 @@ If the request is not successful, the client returns an `HTTPError` containing t
 
 |Status|Description|
 |:---|:---|
+|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
+|#`received`|The provider has printed and dispatched the letter.|
+|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
 |#`pending-virus-check`|GOV.UK Notify has not completed a virus scan of the precompiled letter file.|
 |#`virus-scan-failed`|GOV.UK Notify found a potential virus in the precompiled letter file.|
 |#`validation-failed`|Content in the precompiled letter file is outside the printable area. See the [GOV.UK Notify letter specification](https://www.notifications.service.gov.uk/using-notify/guidance/letter-specification) for more information.|
-|#`accepted`|GOV.UK Notify has sent the letter to the provider to be printed.|
-|#`cancelled`|Sending cancelled. The letter will not be printed or dispatched.|
-|#`received`|The provider has printed and dispatched the letter.|
 |#`technical-failure`|GOV.UK Notify had an unexpected error while sending the letter to our printing provider.|
 |#`permanent-failure`|The provider cannot print the letter. Your letter will not be dispatched.|
 


### PR DESCRIPTION
Move status descriptions under the two get message methods. Use the same status description for all client docs.

