### PR TITLE
Support encoding sets in JSON POST data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.1
+
+* Auto-convert sets to lists in API calls
+
 ## 6.2.0
 
 * Optionally include job notifications in `get_all_notifications`

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.2.0'
+__version__ = '6.2.1'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -74,7 +74,7 @@ class BaseAPIClient(object):
         }
 
         if data is not None:
-            kwargs.update(data=json.dumps(data))
+            kwargs.update(data=self._serialize_data(data))
 
         if params is not None:
             kwargs.update(params=params)
@@ -82,6 +82,15 @@ class BaseAPIClient(object):
         url = urllib.parse.urljoin(str(self.base_url), str(url))
 
         return url, kwargs
+
+    def _serialize_data(self, data):
+        return json.dumps(data, default=self._extended_json_encoder)
+
+    def _extended_json_encoder(self, obj):
+        if isinstance(obj, set):
+            return list(obj)
+
+        raise TypeError
 
     def _perform_request(self, method, url, kwargs):
         start_time = time.monotonic()

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -110,4 +110,17 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.2.0"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.2.1"
+
+
+@pytest.mark.parametrize('data, expected_json', [
+    [{'list': {1, 2}}, {'list': [1, 2]}]
+])
+def test_converts_extended_types_to_json(base_client, rmock, data, expected_json):
+    rmock.request(
+        "GET",
+        "http://test-host/",
+        json=expected_json,
+    )
+
+    base_client.request('GET', '/', data=data)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178770155

Sets are just a special kind of list, so there's no reason why we
can't support them in POST data. Rather than peppering our code with
list(set) conversions (and testing them), it seems more pragmatic to
do it once where we can get the most benefit from it.

One use case for this will be POSTing permissions from Admin to API.
Admin uses sets for permissions most of the time, which means we get
an error if we try to POST them directly:

      File "/Users/benthorner/.pyenv/versions/3.6.12/lib/python3.6/json/encoder.py", line 180, in default
        o.__class__.__name__)
      TypeError: Object of type 'set' is not JSON serializable


<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`