### PR TITLE
Only include source in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.1
+
+* Remove test directories from distributed package
+
 ## 6.3.0
 
 * Added a default timeout of 30s to the `BaseAPIClient`

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -4,13 +4,10 @@ import uuid
 from datetime import datetime
 from io import BytesIO
 
+from enums import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
 from jsonschema import Draft4Validator
-
-from integration_test.enums import EMAIL_TYPE, LETTER_TYPE, SMS_TYPE
-from integration_test.schemas.v2.inbound_sms_schemas import (
-    get_inbound_sms_response,
-)
-from integration_test.schemas.v2.notification_schemas import (
+from schemas.v2.inbound_sms_schemas import get_inbound_sms_response
+from schemas.v2.notification_schemas import (
     get_notification_response,
     get_notifications_response,
     post_email_response,
@@ -18,13 +15,12 @@ from integration_test.schemas.v2.notification_schemas import (
     post_precompiled_letter_response,
     post_sms_response,
 )
-from integration_test.schemas.v2.template_schemas import (
+from schemas.v2.template_schemas import (
     get_template_by_id_response,
     post_template_preview_response,
 )
-from integration_test.schemas.v2.templates_schemas import (
-    get_all_template_response,
-)
+from schemas.v2.templates_schemas import get_all_template_response
+
 from notifications_python_client.errors import HTTPError
 from notifications_python_client.notifications import NotificationsAPIClient
 

--- a/integration_test/schemas/v2/template_schemas.py
+++ b/integration_test/schemas/v2/template_schemas.py
@@ -1,5 +1,5 @@
-from integration_test.enums import TEMPLATE_TYPES
-from integration_test.schemas.v2.definitions import personalisation, uuid
+from enums import TEMPLATE_TYPES
+from schemas.v2.definitions import personalisation, uuid
 
 get_template_by_id_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/integration_test/schemas/v2/templates_schemas.py
+++ b/integration_test/schemas/v2/templates_schemas.py
@@ -1,7 +1,5 @@
-from integration_test.enums import TEMPLATE_TYPES
-from integration_test.schemas.v2.template_schemas import (
-    get_template_by_id_response as template,
-)
+from enums import TEMPLATE_TYPES
+from schemas.v2.template_schemas import get_template_by_id_response as template
 
 get_all_template_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.3.0'
+__version__ = '6.3.1'
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,9 @@ setup(
     ],
     keywords='gds govuk notify',
 
-    packages=find_packages(),
+    packages=find_packages(
+        include=['notifications_python_client'],
+    ),
     include_package_data=True,
 
     # only support actively patched versions of python (https://devguide.python.org/devcycle/#end-of-life-branches)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,12 @@ setup(
     keywords='gds govuk notify',
 
     packages=find_packages(
-        include=['notifications_python_client'],
+        exclude=[
+            'integration_test',
+            'scripts',
+            'tests',
+            'utils',
+        ],
     ),
     include_package_data=True,
 


### PR DESCRIPTION
Copies the approach taken in https://github.com/alphagov/notifications-utils/pull/898

It's unlikely we'll add any separate packages, and this prevents us accidentally bundling the integration tests folder in.

This was previously resulting in a tests folder being found in the site_packages in a virtualenv, containing all the integration tests from the Python client in every venv that required the Python client repo.

Fixes https://github.com/alphagov/notifications-python-client/issues/205

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
