### PR TITLE
Updated client to establish a default timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.0
+
+* Added a default timeout of 30s to the `BaseAPIClient`
+
 ## 6.2.1
 
 * Auto-convert sets to lists in API calls

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -25,6 +25,7 @@ notifications_client = NotificationsAPIClient(api_key)
 ```
 
 To get an API key, [sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in) and go to the __API integration__ page. You can find more information in the [API keys](#api-keys) section of this documentation.
+The default timeout for the APIClient is 30.
 
 ## Send a message
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.2.1'
+__version__ = '6.3.0'
 
 from notifications_python_client.errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa
 

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -17,13 +17,15 @@ class BaseAPIClient(object):
     def __init__(
             self,
             api_key,
-            base_url='https://api.notifications.service.gov.uk'
+            base_url='https://api.notifications.service.gov.uk',
+            timeout=30
     ):
         """
         Initialise the client
         Error if either of base_url or secret missing
         :param base_url - base URL of GOV.UK Notify API:
         :param secret - application secret - used to sign the request:
+        :param timeout - request timeout on the client
         :return:
         """
         service_id = api_key[-73:-37]
@@ -35,6 +37,7 @@ class BaseAPIClient(object):
         self.base_url = base_url
         self.service_id = service_id
         self.api_key = api_key
+        self.timeout = timeout
 
     def put(self, url, data):
         return self.request("PUT", url, data=data)
@@ -71,6 +74,7 @@ class BaseAPIClient(object):
 
         kwargs = {
             "headers": self.generate_headers(api_token),
+            "timeout": self.timeout
         }
 
         if data is not None:

--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -28,6 +28,15 @@ def test_can_set_base_url():
     assert client.base_url == 'foo'
 
 
+def test_set_timeout():
+    client = BaseAPIClient(base_url='foo', api_key=COMBINED_API_KEY, timeout=2)
+    assert client.timeout == 2
+
+
+def test_default_timeout_is_set(base_client):
+    assert base_client.timeout == 30
+
+
 def test_fails_if_client_id_missing():
     with pytest.raises(AssertionError) as err:
         BaseAPIClient(api_key=API_KEY_ID)
@@ -110,7 +119,7 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.2.1"
+    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.3.0"
 
 
 @pytest.mark.parametrize('data, expected_json', [


### PR DESCRIPTION
The current client didnt have a default timeout
when establishing an HTTP connection.
This can lead to hanging connections
if there is no network connectivity.
Added a default timeout to the BaseAPIClient.
This timeout is configurable.
Edited the tests to take the timeout param.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [ ] `CHANGELOG.md`
- [ ] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
