### PR TITLE
Assert on version number format, not exact number

### DIFF
--- a/tests/notifications_python_client/test_base_api_client.py
+++ b/tests/notifications_python_client/test_base_api_client.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import re
+
 import mock
 import pytest
 import requests
@@ -119,7 +121,10 @@ def test_user_agent_is_set(base_client, rmock):
 
     base_client.request('GET', '/')
 
-    assert rmock.last_request.headers.get("User-Agent") == "NOTIFY-API-PYTHON-CLIENT/6.3.0"
+    assert re.fullmatch(
+        r'NOTIFY-API-PYTHON-CLIENT\/(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)',
+        rmock.last_request.headers.get("User-Agent"),
+    )
 
 
 @pytest.mark.parametrize('data, expected_json', [


### PR DESCRIPTION
It’s annoying to have to bump the tests every time the version number changes. This commit changes the assertion to just check that the version number is in the correct format, not that it’s an exact match.

The regex is adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string which looks like:
```regexp
^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
```

I’ve cut it down to only look at `MAJOR.MINOR.PATCH`, since we don’t do alpha/beta/pre-release versions of this library.

Other options we chose not to go with:
- delete this test entirely
- `assert […].startswith('NOTIFY-API-PYTHON-CLIENT')`

We used to have the latter and it caused a bug where the version number in the user agent was set to `None` and we didn’t notice. We think this is why the version number was added to the test in https://github.com/alphagov/notifications-python-client/pull/67

