### PR TITLE
Add support for new doc download features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.4.0
+
+* Added support for `confirm_email_before_download` and `retention_period` security features for sending files by email.
+
 ## 6.3.0
 
 * Added a default timeout of 30s to the `BaseAPIClient`

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -216,9 +216,16 @@ You can leave out this argument if your service only has one reply-to email addr
 
 To send a file by email, add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file.
 
-The file will be available for the recipient to download for 18 months.
-
 The links are unique and unguessable. GOV.UK Notify cannot access or decrypt your file.
+
+Your file will be available to download for a default period of 78 weeks (18 months). From 29 March 2023 we will reduce this to 26 weeks (6 months) for all new files. Files sent before 29 March will not be affected.
+
+To help protect your files you can also:
+
+* ask recipients to confirm their email address before downloading
+* choose the length of time that a file is available to download
+
+To turn these features on or off, you will need version 6.4.0 of the Python client library or a more recent version.
 
 #### Add contact details to the file download page
 
@@ -232,9 +239,9 @@ The links are unique and unguessable. GOV.UK Notify cannot access or decrypt you
 1. [Sign in to GOV.UK Notify](https://www.notifications.service.gov.uk/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example:
+1. Add a placeholder to the email template using double brackets. For example: "Download your file at: ((link_to_file))"
 
-"Download your file at: ((link_to_file))"
+Your email should also tell recipients how long the file will be available to download.
 
 #### Upload your file
 
@@ -271,6 +278,83 @@ with open('file.csv', 'rb') as f:
     }
 ```
 
+#### Ask recipients to confirm their email address before they can download the file
+
+This new security feature is optional. You should use it if you send files that are sensitive - for example, because they contain personal information about your users.
+
+When a recipient clicks the link in the email you’ve sent them, they have to enter their email address. Only someone who knows the recipient’s email address can download the file.
+
+From 29 March 2023, we will turn this feature on by default for every file you send. Files sent before 29 March will not be affected.
+
+##### Turn on email address check
+
+To use this feature before 29 March 2023 you will need version 6.4.0 of the Python client library, or a more recent version.
+
+To make the recipient confirm their email address before downloading the file, set the `confirm_email_before_download` flag to `True`.
+
+You will not need to do this after 29 March.
+
+```python
+from notifications_python_client import prepare_upload
+
+with open('file.pdf', 'rb') as f:
+    ...
+    personalisation={
+      'first_name': 'Amala',
+      'application_date': '2018-01-01',
+      'link_to_file': prepare_upload(f, confirm_email_before_download=True),
+    }
+```
+
+##### Turn off email address check (not recommended)
+
+If you do not want to use this feature after 29 March 2023, you can turn it off on a file-by-file basis.
+
+To do this you will need version 6.4.0 of the Python client library, or a more recent version.
+
+You should not turn this feature off if you send files that contain:
+
+* personally identifiable information
+* commercially sensitive information
+* information classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the [Government Security Classifications](https://www.gov.uk/government/publications/government-security-classifications) policy
+
+To let the recipient download the file without confirming their email address, set the `confirm_email_before_download` flag to `False`.
+
+
+```python
+from notifications_python_client import prepare_upload
+
+with open('file.pdf', 'rb') as f:
+    ...
+    personalisation={
+      'first_name': 'Amala',
+      'application_date': '2018-01-01',
+      'link_to_file': prepare_upload(f, confirm_email_before_download=False),
+    }
+```
+
+#### Choose the length of time that a file is available to download
+
+Set the number of weeks you want the file to be available using the `retention_period` key.
+
+You can choose any value between 1 week and 78 weeks.
+
+To use this feature will need version 6.4.0 of the Python client library, or a more recent version.
+
+If you do not choose a value, the file will be available for the default period of 78 weeks (18 months).
+
+```python
+from notifications_python_client import prepare_upload
+
+with open('file.pdf', 'rb') as f:
+    ...
+    personalisation={
+      'first_name': 'Amala',
+      'application_date': '2018-01-01',
+      'link_to_file': prepare_upload(f, retention_period='4 weeks'),
+    }
+```
+
 #### Response
 
 If the request to the client is successful, the client returns a `dict`:
@@ -302,6 +386,8 @@ If the request is not successful, the client returns an `HTTPError` containing t
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](#api-keys)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"`<br>`}]`|Your service cannot send this email in [trial mode](https://www.notifications.service.gov.uk/features/using-notify#trial-mode)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)'"`<br>`}]`|Wrong file type. You can only upload .pdf, .csv, .txt, .doc, .docx, .xlsx, .rtf or .odt files|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported value for retention_period '(PERIOD)'. Supported periods are from 1 to 78 weeks."`<br>`}]`|Choose a period between 1 and 78 weeks|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported value for confirm_email_before_download: '(VALUE)'. Use a boolean true or false value."`<br>`}]`|Use either True or False|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|The file contains a virus|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service at https://www.notifications.service.gov.uk/services/(SERVICE ID)/service-settings/send-files-by-email"`<br>`}]`|See how to [add contact details to the file download page](#add-contact-details-to-the-file-download-page)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can only send a file by email"`<br>`}]`|Make sure you are using an email template|

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.3.0'
+__version__ = '6.4.0'
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/utils.py
+++ b/notifications_python_client/utils.py
@@ -3,13 +3,17 @@ import base64
 DOCUMENT_UPLOAD_SIZE_LIMIT = 2 * 1024 * 1024
 
 
-def prepare_upload(f, is_csv=False):
+def prepare_upload(f, is_csv=False, confirm_email_before_download=None, retention_period=None):
     contents = f.read()
 
     if len(contents) > DOCUMENT_UPLOAD_SIZE_LIMIT:
         raise ValueError('File is larger than 2MB')
 
-    return {
+    file_data = {
         'file': base64.b64encode(contents).decode('ascii'),
         'is_csv': is_csv,
+        'confirm_email_before_download': confirm_email_before_download,
+        'retention_period': retention_period
     }
+
+    return file_data

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -271,7 +271,12 @@ def test_create_email_notification_with_document_stream_upload(notifications_cli
         'template_id': '456', 'email_address': 'to@example.com',
         'personalisation': {
             'name': 'chris',
-            'doc': {'file': 'ZmlsZS1jb250ZW50cw==', 'is_csv': False}
+            'doc': {
+                'file': 'ZmlsZS1jb250ZW50cw==',
+                'is_csv': False,
+                'confirm_email_before_download': None,
+                'retention_period': None
+            },
         }
     }
 
@@ -296,7 +301,12 @@ def test_create_email_notification_with_document_file_upload(notifications_clien
         'template_id': '456', 'email_address': 'to@example.com',
         'personalisation': {
             'name': 'chris',
-            'doc': {'file': 'JVBERi0xLjUgdGVzdAo=', 'is_csv': False}
+            'doc': {
+                'file': 'JVBERi0xLjUgdGVzdAo=',
+                'is_csv': False,
+                'confirm_email_before_download': None,
+                'retention_period': None
+            },
         }
     }
 
@@ -321,7 +331,12 @@ def test_create_email_notification_with_csv_file_upload(notifications_client, rm
         'template_id': '456', 'email_address': 'to@example.com',
         'personalisation': {
             'name': 'chris',
-            'doc': {'file': 'VGhpcyBpcyBhIGNzdiwK', 'is_csv': True}
+            'doc': {
+                'file': 'VGhpcyBpcyBhIGNzdiwK',
+                'is_csv': True,
+                'confirm_email_before_download': None,
+                'retention_period': None
+            },
         }
     }
 

--- a/tests/notifications_python_client/test_utils.py
+++ b/tests/notifications_python_client/test_utils.py
@@ -20,9 +20,35 @@ def test_prepare_upload_raises_an_error_for_large_files():
         False,
     )
 )
-def test_prepare_upload_generates_expected_dict(is_csv):
+@pytest.mark.parametrize(
+    'confirm_email_before_download',
+    (
+        None,
+        True,
+        False,
+    )
+)
+@pytest.mark.parametrize(
+    'retention_period',
+    (
+        None,
+        '1 week',
+        '1 weeks',
+        '4 weeks',
+        '78 weeks',
+        'bad string',  # Validations happens on the API only
+    )
+)
+def test_prepare_upload_generates_expected_dict(is_csv, confirm_email_before_download, retention_period):
     file_content = b'a' * 256
-    file_dict = prepare_upload(io.BytesIO(file_content), is_csv=is_csv)
+    file_dict = prepare_upload(
+        io.BytesIO(file_content),
+        is_csv=is_csv,
+        confirm_email_before_download=confirm_email_before_download,
+        retention_period=retention_period
+    )
 
-    assert file_dict['is_csv'] == is_csv
+    assert file_dict['is_csv'] is is_csv
     assert file_dict['file'] == base64.b64encode(file_content).decode('ascii')
+    assert file_dict['confirm_email_before_download'] is confirm_email_before_download
+    assert file_dict['retention_period'] is retention_period


### PR DESCRIPTION
Pass through `confirm_email_before_download` and `retention_period` parameters via `prepare_upload` calls so that clients can start to explicitly opt-in or opt-out of the new security features.

Bump client to v6.4.0