### PR TITLE
Handle PyJWT 2.6.0 ImmatureSignatureError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.4.1
+
+* Fix authentication when using PyJWT 2.6.0 - which now more strictly validates tokens with `iat` in the future.
+
 ## 6.4.0
 
 * Added support for `confirm_email_before_download` and `retention_period` security features for sending files by email.

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.4.0'
+__version__ = '6.4.1'
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/authentication.py
+++ b/notifications_python_client/authentication.py
@@ -16,6 +16,8 @@ __algorithm__ = "HS256"
 __type__ = "JWT"
 __bound__ = 30
 
+INVALID_FUTURE_TOKEN_ERROR_MESSAGE = "Token can not be in the future"
+
 
 def create_jwt_token(secret, client_id):
     """
@@ -104,6 +106,8 @@ def decode_jwt_token(token, secret):
         return validate_jwt_token(decoded_token)
     except jwt.InvalidIssuedAtError:
         raise TokenExpiredError("Token has invalid iat field", decode_token(token))
+    except jwt.ImmatureSignatureError:
+        raise TokenExpiredError(INVALID_FUTURE_TOKEN_ERROR_MESSAGE, decode_token(token))
     except jwt.DecodeError:
         raise TokenDecodeError
     except jwt.InvalidAlgorithmError:
@@ -131,7 +135,7 @@ def validate_jwt_token(decoded_token):
     if now > (iat + __bound__):
         raise TokenExpiredError("Token has expired", decoded_token)
     if iat > (now + __bound__):
-        raise TokenExpiredError("Token can not be in the future", decoded_token)
+        raise TokenExpiredError(INVALID_FUTURE_TOKEN_ERROR_MESSAGE, decoded_token)
 
     return True
 

--- a/tests/notifications_python_client/test_authentication.py
+++ b/tests/notifications_python_client/test_authentication.py
@@ -55,7 +55,6 @@ def test_token_should_fail_to_decode_if_wrong_key():
 
 @pytest.mark.parametrize('exception_class', [
     jwt.InvalidAudienceError,
-    jwt.ImmatureSignatureError,
     jwt.InvalidIssuerError,
     jwt.ExpiredSignatureError,
 


### PR DESCRIPTION
If tokens are issued too far in the future, PyJWT >=2.6.0 now seems to throw ImmatureSignatureError rather than InvalidIssuedAtError, which is what we expect.

As we don't catch the new error correctly this bubbles up and causes a test failure on
test_should_reject_token_that_is_just_out_of_bounds_futured.

So now we're potentially validating `iat` in two places, depending on which version of PyJWT users have installed. We still need to do the check locally in case users are on <2.6.0.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
- [x] I've added new environment variables to
  - [x] `notifications-python-client/scripts/generate_docker_env.sh`
  - [x] `notifications-python-client/tox.ini`
  - [x] `CONTRIBUTING.md`
