### PR TITLE
Package without tests (by @ushkarev)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@
   - [ ] `CHANGELOG.md`
 - [ ] I’ve bumped the version number in
   - [ ] `notifications_python_client/__init__.py`
-  - [ ] `notifications_python_client/test_base_api_client.py`, function `test_user_agent_is_set`
 - [ ] I've added new environment variables to
   - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
   - [ ] `notifications-python-client/tox.ini`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 7.0.0
 
 * PyPI distribution no longer includes `integration_test`, `tests` and `utils` modules which were not intended for client use.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* PyPI distribution no longer includes `integration_test`, `tests` and `utils` modules which were not intended for client use.
+
 ## 6.4.1
 
 * Fix authentication when using PyJWT 2.6.0 - which now more strictly validates tokens with `iat` in the future.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include Makefile  *.txt *.md
-recursive-include *.py
+include *.txt
+include *.md
 include notifications_python_client/py.typed

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: ## Run tests
 
 .PHONY: integration-test
 integration-test: ## Run integration tests
-	python integration_test/integration_tests.py
+	python -m integration_test.integration_tests
 
 .PHONY: build-wheel
 build-wheel: ## build distributable wheel

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = '6.4.1'
+__version__ = '7.0.0'
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,10 +5,6 @@ test=pytest
 addopts = --verbose
 python_files = tests/**
 
-[bdist_wheel]
-# this flags the wheel as being python 2 and 3 compatible
-universal = 1
-
 [isort]
 line_length=80
 indent='    '

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     keywords='gds govuk notify',
 
-    packages=find_packages(),
+    packages=find_packages(include=['notifications_python_client']),
     include_package_data=True,
 
     # only support actively patched versions of python (https://devguide.python.org/devcycle/#end-of-life-branches)


### PR DESCRIPTION
Copied from #219 

---

# What problem does the pull request solve?
Anyone trying to install the package from PyPI will also download unnecessary test files and utilities. The [latest package on PyPI](https://pypi.org/project/notifications-python-client/6.4.1/#files) only has a binary distribution wheel and it contains:

```
.
├── notifications_python_client-6.4.1.dist-info
│   ├── LICENSE
│   ├── METADATA
│   ├── RECORD
│   ├── WHEEL
│   └── top_level.txt
├── notifications_python_client
│   ├── __init__.py
│   ├── authentication.py
│   ├── base.py
│   ├── errors.py
│   ├── notifications.py
│   ├── py.typed
│   └── utils.py
├── integration_test    ← this folder should not be included
│   ├── __init__.py
│   ├── enums.py
│   ├── integration_tests.py
│   └── schemas
│       ├── __init__.py
│       └── v2
│           ├── __init__.py
│           ├── definitions.py
│           ├── inbound_sms_schemas.py
│           ├── notification_schemas.py
│           ├── template_schemas.py
│           └── templates_schemas.py
├── tests               ← this folder should not be included
│   ├── __init__.py
│   └── conftest.py
└── utils               ← this folder should not be included
    ├── __init__.py
    └── make_api_call.py
```

The highlighted test and utility files are not intended for consumers of this client library, rather the developers and testers who are using the source repository.

Furthermore, these top-level module names are very generic and are not unlikely to clash with users’ code.

Aims to address issue #205.

# Checklist

- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes – not relevant; PyPI package wasn’t tested previously either
- [x] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md` – no relevant changes
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in – no, because it’s better done by the GOV.UK Notify team, though I would suggest a major version change since the public (if undocumented) api significantly changes
  - [x] `notifications_python_client/__init__.py`
- [ ] I've added new environment variables to – no relevant changes
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh` – I presume this is supposed to say `run_with_docker.sh`, but maybe it’s not even needed anymore?
  - [x] `notifications-python-client/tox.ini` – no relevant changes
  - [ ] `CONTRIBUTING.md` – should this be under environment variables?
