### PR TITLE
re-use a single request session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.0
+
+* Reuse the same `requests.session` between requests to increase performance through HTTP Keepalive
+
 ## 8.0.1
 
 * Some minor non-functional code reformatting.

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "8.0.1"
+__version__ = "8.1.0"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -32,6 +32,7 @@ class BaseAPIClient(object):
         self.service_id = service_id
         self.api_key = api_key
         self.timeout = timeout
+        self.request_session = requests.Session()
 
     def put(self, url, data):
         return self.request("PUT", url, data=data)
@@ -87,7 +88,7 @@ class BaseAPIClient(object):
     def _perform_request(self, method, url, kwargs):
         start_time = time.monotonic()
         try:
-            response = requests.request(method, url, **kwargs)
+            response = self.request_session.request(method, url, **kwargs)
             response.raise_for_status()
             return response
         except requests.RequestException as e:


### PR DESCRIPTION
This should unlock performance benefits by utilising HTTP keep-alive to reuse one TCP connection between many requests. Quoth the docs:

[The Session object] across all requests [...] will use urllib3’s connection pooling. So if you’re making several requests to the same host, the underlying TCP connection will be reused, which can result in a significant performance increase (see HTTP persistent connection).[^1]

Tested very unscientifically locally, 500 test notifications took 39 seconds, down from 52 seconds. (25% faster)

[^1]: https://requests.readthedocs.io/en/latest/user/advanced/

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [ ] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
