### PR TITLE
Allow setting custom filenames for documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+## 9.0.0
+
+* Removes the `is_csv` parameter to `prepare_upload`.
+* Adds the `filename` parameter to `prepare_upload`. See [our documentation](https://docs.notifications.service.gov.uk/python.html#send-a-file-by-email) for guidance on how to use this.
+
 ## 8.2.0
 
 * Add support for python 3.12

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -264,13 +264,20 @@ with open('file.pdf', 'rb') as f:
 
 #### Set the filename
 
-You can provide a filename to set when the recipient downloads the file. If this is not provided, a random filename will be generated.
+To do this you will need version 9.0.0 of the Python client library, or a more recent version.
 
-Choosing a sensible filename can help users understand what the file contains, and find it again later.
+You should provide a filename when you upload your file.
 
-You do not have to set this, but we strongly recommend it.
+The filename should tell the recipient what the file contains. A memorable filename can help the recipient to find the file again later.
 
-The filename must include the correct file extension, such as `.csv` for a CSV file. If you include the wrong file extension, users may not be able to open your file.
+The filename must end with a file extension. For example, `.csv` for a CSV file. If you include the wrong file extension, recipients may not be able to open your file.
+
+If you do not provide a filename for your file, Notify will:
+
+* generate a random filename
+* try to add the correct file extension
+
+If Notify cannot add the correct file extension, recipients may not be able to open your file.
 
 ```python
 from notifications_python_client import prepare_upload

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -262,10 +262,15 @@ with open('file.pdf', 'rb') as f:
     }
 ```
 
-##### CSV Files
+#### Set the filename
 
-Uploads for CSV files should use the `is_csv` parameter
-on the `prepare_upload()` utility.  For example:
+You can provide a filename to set when the recipient downloads the file. If this is not provided, a random filename will be generated.
+
+Choosing a sensible filename can help users understand what the file contains, and find it again later.
+
+You do not have to set this, but we strongly recommend it.
+
+The filename must include the correct file extension, such as `.csv` for a CSV file. If you include the wrong file extension, users may not be able to open your file.
 
 ```python
 from notifications_python_client import prepare_upload
@@ -275,7 +280,7 @@ with open('file.csv', 'rb') as f:
     personalisation={
       'first_name': 'Amala',
       'application_date': '2018-01-01',
-      'link_to_file': prepare_upload(f, is_csv=True),
+      'link_to_file': prepare_upload(f, filename='2023-12-25-daily-report.csv'),
     }
 ```
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "8.2.0"
+__version__ = "9.0.0"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/utils.py
+++ b/notifications_python_client/utils.py
@@ -3,7 +3,7 @@ import base64
 DOCUMENT_UPLOAD_SIZE_LIMIT = 2 * 1024 * 1024
 
 
-def prepare_upload(f, is_csv=False, confirm_email_before_download=None, retention_period=None):
+def prepare_upload(f, filename=None, confirm_email_before_download=None, retention_period=None):
     contents = f.read()
 
     if len(contents) > DOCUMENT_UPLOAD_SIZE_LIMIT:
@@ -11,7 +11,7 @@ def prepare_upload(f, is_csv=False, confirm_email_before_download=None, retentio
 
     file_data = {
         "file": base64.b64encode(contents).decode("ascii"),
-        "is_csv": is_csv,
+        "filename": filename,
         "confirm_email_before_download": confirm_email_before_download,
         "retention_period": retention_period,
     }

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -197,7 +197,7 @@ def test_create_email_notification_with_document_stream_upload(notifications_cli
             "name": "chris",
             "doc": {
                 "file": "ZmlsZS1jb250ZW50cw==",
-                "is_csv": False,
+                "filename": None,
                 "confirm_email_before_download": None,
                 "retention_period": None,
             },
@@ -223,7 +223,7 @@ def test_create_email_notification_with_document_file_upload(notifications_clien
             "name": "chris",
             "doc": {
                 "file": "JVBERi0xLjUgdGVzdAo=",
-                "is_csv": False,
+                "filename": None,
                 "confirm_email_before_download": None,
                 "retention_period": None,
             },
@@ -239,7 +239,7 @@ def test_create_email_notification_with_csv_file_upload(notifications_client, rm
         notifications_client.send_email_notification(
             email_address="to@example.com",
             template_id="456",
-            personalisation={"name": "chris", "doc": prepare_upload(f, is_csv=True)},
+            personalisation={"name": "chris", "doc": prepare_upload(f, filename="file.csv")},
         )
 
     assert rmock.last_request.json() == {
@@ -249,7 +249,7 @@ def test_create_email_notification_with_csv_file_upload(notifications_client, rm
             "name": "chris",
             "doc": {
                 "file": "VGhpcyBpcyBhIGNzdiwK",
-                "is_csv": True,
+                "filename": "file.csv",
                 "confirm_email_before_download": None,
                 "retention_period": None,
             },

--- a/tests/notifications_python_client/test_utils.py
+++ b/tests/notifications_python_client/test_utils.py
@@ -14,10 +14,11 @@ def test_prepare_upload_raises_an_error_for_large_files():
 
 
 @pytest.mark.parametrize(
-    "is_csv",
+    "filename",
     (
-        True,
-        False,
+        None,
+        "file.csv",
+        "file.pdf",
     ),
 )
 @pytest.mark.parametrize(
@@ -39,16 +40,16 @@ def test_prepare_upload_raises_an_error_for_large_files():
         "bad string",  # Validations happens on the API only
     ),
 )
-def test_prepare_upload_generates_expected_dict(is_csv, confirm_email_before_download, retention_period):
+def test_prepare_upload_generates_expected_dict(filename, confirm_email_before_download, retention_period):
     file_content = b"a" * 256
     file_dict = prepare_upload(
         io.BytesIO(file_content),
-        is_csv=is_csv,
+        filename=filename,
         confirm_email_before_download=confirm_email_before_download,
         retention_period=retention_period,
     )
 
-    assert file_dict["is_csv"] is is_csv
+    assert file_dict["filename"] == filename
     assert file_dict["file"] == base64.b64encode(file_content).decode("ascii")
     assert file_dict["confirm_email_before_download"] is confirm_email_before_download
     assert file_dict["retention_period"] is retention_period


### PR DESCRIPTION
Allow services to specify the download filename for any files they send
by email.

This takes precedence over the `is_csv` parameter, which provided
limited and flawed functionality.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation in
  - [x] `DOCUMENTATION.md`
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
- [x] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
