### PR TITLE
retain existing exception when raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.1.0
+
+* Chain RequestExceptions when raising an HTTPError so users can view the full context in stack traces etc
 
 ## 9.0.0
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "9.0.0"
+__version__ = "9.1.0"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -96,7 +96,7 @@ class BaseAPIClient(object):
             logger.warning(
                 "API %s request on %s failed with %s '%s'", method, url, api_error.status_code, api_error.message
             )
-            raise api_error
+            raise api_error from e
         finally:
             elapsed_time = time.monotonic() - start_time
             logger.debug("API %s request on %s finished in %s", method, url, elapsed_time)


### PR DESCRIPTION
this'll enable us/users to interrogate the original raw request exception if they need more context

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_python.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
