### PR TITLE
Add Makefile command to bump utils version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ bootstrap: ## Install build dependencies
 .PHONY: build
 build: bootstrap ## Build project (dummy task for CI)
 
+.PHONY: bump-utils
+bump-utils:  # Bump notifications-utils package to latest version
+	python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
+
 .PHONY: test
 test: ## Run tests
 	ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file is automatically copied from notifications-utils@80.0.1
+# This file is automatically copied from notifications-utils@82.1.2
 
 [tool.black]
 line-length = 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # `requirements.txt` so that the version_tools scripts in utils can inspect
 # it to work out the current utils version
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@80.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@
 # `requirements.txt` so that the version_tools scripts in utils can inspect
 # it to work out the current utils version
 
+# Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.1.2


### PR DESCRIPTION
We have this `make` command in most of our other repos, for example the admin app: https://github.com/alphagov/notifications-admin/blob/main/Makefile#L85-L87

***

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/1137