### PR TITLE
BaseAPIClient: add docstring mentioning class is not thread-safe

### DIFF
--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -13,6 +13,12 @@ logger = logging.getLogger(__name__)
 
 
 class BaseAPIClient:
+    """
+    Base class for GOV.UK Notify API client.
+
+    This class is not thread-safe.
+    """
+
     def __init__(self, api_key, base_url="https://api.notifications.service.gov.uk", timeout=30):
         """
         Initialise the client


### PR DESCRIPTION
FWIW this isn't necessarily a _bad_ thing, it's just something users should be aware of if running in a multi-threaded context.

I guess we should also add this information to the user-facing documentation with a hint about what it means and what users can do about it.