### PR TITLE
Make the integration tests compatible with the dev environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,24 @@
 FROM debian:buster
 
 ENV PYTHONUNBUFFERED=1 \
-	DEBIAN_FRONTEND=noninteractive
+    DEBIAN_FRONTEND=noninteractive
 
-RUN \
-	echo "Install base packages" \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		awscli \
-		gcc \
-		git \
-		gnupg \
-		curl \
-		ca-certificates \
-		jq \
-		# pyenv dependencies (https://github.com/pyenv/pyenv/wiki#suggested-build-environment)
-		make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-		libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
-		libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-	&& echo "Clean up" \
-	&& rm -rf /tmp/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      awscli \
+      gcc \
+      git \
+      gnupg \
+      curl \
+      ca-certificates \
+      jq \
+      # pyenv dependencies (https://github.com/pyenv/pyenv/wiki#suggested-build-environment)
+      make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
+      libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
+      libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN \
-	echo "install pyenv" \
-	&& curl https://pyenv.run | bash
+RUN curl https://pyenv.run | bash
 
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
@@ -34,9 +29,7 @@ WORKDIR /var/project
 
 COPY tox-python-versions .
 
-RUN \
-	echo "Install python based on tox-python-versions file" \
-	&& xargs -a tox-python-versions -n 1 -P $(nproc) pyenv install
+RUN xargs -a tox-python-versions -n 1 -P $(nproc) pyenv install
 
 COPY . .
 
@@ -46,6 +39,4 @@ RUN pyenv global $(tr '\n' ' ' < tox-python-versions)
 
 RUN make bootstrap
 
-RUN \
-	echo "installing tox" \
-	&& pip install tox
+RUN pip install tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ WORKDIR /var/project
 COPY tox-python-versions .
 
 RUN \
-	echo "Install python based on .python-version file" \
-	&& while read line; do pyenv install "$line" < /dev/null; done < tox-python-versions
+	echo "Install python based on tox-python-versions file" \
+	&& xargs -a tox-python-versions -n 1 -P $(nproc) pyenv install
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,13 @@ RUN \
 	echo "Install base packages" \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
+		awscli \
 		gcc \
 		git \
 		gnupg \
 		curl \
 		ca-certificates \
+		jq \
 		# pyenv dependencies (https://github.com/pyenv/pyenv/wiki#suggested-build-environment)
 		make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
 		libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev \
@@ -36,7 +38,6 @@ RUN \
 	echo "Install python based on .python-version file" \
 	&& while read line; do pyenv install "$line" < /dev/null; done < tox-python-versions
 
-# Make all files available so we can run "make bootstrap" and install dependencies.
 COPY . .
 
 # Make pyenv activate all installed Python versions for tox (available as pythonX.Y)

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -119,12 +119,12 @@ def get_pdf_for_letter(python_client, id):
             if exc.message[0]["error"] != "PDFNotReadyError":
                 raise
 
-            count += 3
-            if count > 45:
-                print(f"pdf {id} not ready at {datetime.utcnow()} after 45 seconds")  # noqa: T201
+            count += 5
+            if count > 120:
+                print(f"pdf {id} not ready at {datetime.utcnow()} after 120 seconds")  # noqa: T201
                 raise
             else:
-                time.sleep(3)
+                time.sleep(5)
 
     assert type(response) == BytesIO
     assert len(response.read()) != 0


### PR DESCRIPTION
[Trello card](https://trello.com/c/D1m5uleD/952-run-api-client-integration-tests-as-part-of-new-pipeline)

Some small updates to make the integration tests runnable in the dev environments via the new deploy pipeline.

[Tested in dev-a](https://concourse.notify.tools/teams/dev-a/pipelines/deploy-notify/jobs/test/builds/162) (5 times in a row to check for flakiness)