### PR TITLE
Fix get_received_texts_iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.0.1
+
+* Fix get_received_texts_iterator() method
+
 ## 10.0.0
 
 * Drop support for end-of-life Python 3.7

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "10.0.0"
+__version__ = "10.0.1"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -72,7 +72,7 @@ class NotificationsAPIClient(BaseAPIClient):
             yield from received_texts
             next_link = result["links"].get("next")
             received_text_id = re.search("[0-F]{8}-[0-F]{4}-[0-F]{4}-[0-F]{4}-[0-F]{12}", next_link, re.I).group(0)
-            result = self.get_received_texts_iterator(older_than=received_text_id)
+            result = self.get_received_texts(older_than=received_text_id)
             received_texts = result.get("received_text_messages")
 
     def get_notification_by_id(self, id):


### PR DESCRIPTION
It was broken as it was calling itself instead of a get_received_texts() function, and so when trying to iterate over results, it would throw an error

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_python.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
