### PR TITLE
`BaseAPIClient`: add `request_session` constructor argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+* BaseAPIClient: add request_session constructor argument
+
 ## 10.0.1
 
 * Fix get_received_texts_iterator() method

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "10.0.1"
+__version__ = "10.1.0"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/base.py
+++ b/notifications_python_client/base.py
@@ -13,7 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class BaseAPIClient:
-    def __init__(self, api_key, base_url="https://api.notifications.service.gov.uk", timeout=30):
+    def __init__(
+        self,
+        api_key,
+        base_url="https://api.notifications.service.gov.uk",
+        timeout=30,
+        request_session=None,
+    ):
         """
         Initialise the client
         Error if either of base_url or secret missing
@@ -32,7 +38,7 @@ class BaseAPIClient:
         self.service_id = service_id
         self.api_key = api_key
         self.timeout = timeout
-        self.request_session = requests.Session()
+        self.request_session = request_session or requests.Session()
 
     def put(self, url, data):
         return self.request("PUT", url, data=data)


### PR DESCRIPTION

## What problem does the pull request solve?
This allows a pre-constructed `requests.Session` object to be used by the api client, which is useful for some esoteric use cases.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [ ] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_python.md)
  - [x] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [x] `notifications_python_client/__init__.py`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
