### PR TITLE
Update test schemas to account for economy postage

### DIFF
--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -26,7 +26,7 @@ get_notification_response = {
         "line_5": {"type": ["string", "null"]},
         "line_6": {"type": ["string", "null"]},
         "postcode": {"type": ["string", "null"]},
-        "postage": {"enum": ["first", "second", None]},
+        "postage": {"enum": ["first", "second", "economy", None]},
         "type": {"enum": ["sms", "letter", "email"]},
         "status": {"type": "string"},
         "template": template,
@@ -201,7 +201,7 @@ post_precompiled_letter_response = {
     "properties": {
         "id": uuid,
         "reference": {"type": ["string", "null"]},
-        "postage": {"enum": ["first", "second", None]},
+        "postage": {"enum": ["first", "second", "economy", None]},
     },
     "required": ["id", "reference"],
 }


### PR DESCRIPTION
This updates the test schemas to reflect the fact that postage will soon be able to be "economy". This is done as a record of the data that can be returned, no changes to the code are necessary in order to start sending economy postage.