### PR TITLE
Allow sanitise_content_for arg in send_email_notification endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 12.1.0
 
-* Adds `sanitise_content_for` parameter to `send_email_notification` enpdpoint. See [our documentation](https://docs.notifications.service.gov.uk/python.html#reducing-the-risk-of-malicious-content-injection-in-placeholders) for guidance on how to use this.
+* Adds `sanitise_content_for` parameter to `send_email_notification` endpoint. See [our documentation](https://docs.notifications.service.gov.uk/python.html#reducing-the-risk-of-malicious-content-injection-in-placeholders) for guidance on how to use this.
 
 ## 12.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.1.0
+
+* Adds `sanitise_content_for` parameter to `send_email_notification` enpdpoint. See [our documentation](https://docs.notifications.service.gov.uk/python.html#reducing-the-risk-of-malicious-content-injection-in-placeholders) for guidance on how to use this.
+
 ## 12.0.0
 
 * Drop support for end-of-life Python 3.9

--- a/integration_test/integration_tests.py
+++ b/integration_test/integration_tests.py
@@ -60,9 +60,11 @@ def send_email_notification_test_response(python_client, reply_to=None):
         personalisation=personalisation,
         one_click_unsubscribe_url=one_click_unsubscribe_url,
         email_reply_to_id=email_reply_to_id,
+        sanitise_content_for=["name"],
     )
     validate(response, post_email_response)
-    assert unique_name in response["content"]["body"]  # check placeholders are replaced
+    # check placeholders are replaced and sanitised:
+    assert unique_name.replace("-", "\\-") in response["content"]["body"]
     return response["id"]
 
 

--- a/integration_test/schemas/v2/notification_schemas.py
+++ b/integration_test/schemas/v2/notification_schemas.py
@@ -115,7 +115,7 @@ post_sms_response = {
     },
     "required": ["id", "content", "uri", "template"],
 }
-
+# TODO: this doesn't seem to be used anywhere, do we still need it?
 post_email_request = {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "description": "POST email notification schema",
@@ -128,6 +128,7 @@ post_email_request = {
         "email_reply_to_id": uuid,
         "personalisation": personalisation,
         "one_click_unsubscribe_url": https_url,
+        "sanitise_content_for": {"type": "array", "items": {"type": "string"}},
     },
     "required": ["email_address", "template_id"],
 }
@@ -156,8 +157,9 @@ post_email_response = {
         "content": email_content,
         "uri": {"type": "string"},
         "template": template,
+        "sanitised_content": {"type": "object"},
     },
-    "required": ["id", "content", "uri", "template"],
+    "required": ["id", "content", "uri", "template", "sanitised_content"],
 }
 
 post_letter_request = {
@@ -217,6 +219,7 @@ def create_post_sms_response_from_notification(notification, body, from_number, 
     }
 
 
+# TODO: we don't seem to be using this, is it needed?
 def create_post_email_response_from_notification(notification, content, subject, email_from, url_root):
     return {
         "id": notification.id,
@@ -224,6 +227,7 @@ def create_post_email_response_from_notification(notification, content, subject,
         "content": {"from_email": email_from, "body": content, "subject": subject},
         "uri": f"{url_root}/v2/notifications/{str(notification.id)}",
         "template": __create_template_from_notification(notification=notification, url_root=url_root),
+        "sanitised_content": {},
     }
 
 

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "12.0.0"
+__version__ = "12.1.0"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/notifications_python_client/notifications.py
+++ b/notifications_python_client/notifications.py
@@ -29,6 +29,7 @@ class NotificationsAPIClient(BaseAPIClient):
         reference=None,
         email_reply_to_id=None,
         one_click_unsubscribe_url=None,
+        sanitise_content_for=None,
     ):
         notification = {"email_address": email_address, "template_id": template_id}
         if personalisation:
@@ -39,6 +40,8 @@ class NotificationsAPIClient(BaseAPIClient):
             notification.update({"email_reply_to_id": email_reply_to_id})
         if one_click_unsubscribe_url:
             notification.update({"one_click_unsubscribe_url": one_click_unsubscribe_url})
+        if sanitise_content_for:
+            notification.update({"sanitise_content_for": sanitise_content_for})
 
         return self.post("/v2/notifications/email", data=notification)
 

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -174,6 +174,25 @@ def test_create_email_notification_with_personalisation(notifications_client, rm
     }
 
 
+def test_create_email_notification_with_sanitise_content_for(notifications_client, rmock):
+    endpoint = f"{TEST_HOST}/v2/notifications/email"
+    rmock.request("POST", endpoint, json={"status": "success"}, status_code=200)
+
+    notifications_client.send_email_notification(
+        email_address="to@example.com",
+        template_id="456",
+        personalisation={"name": "chris", "link": "https://www.safe-link.gov.uk"},
+        sanitise_content_for=["name"],
+    )
+
+    assert rmock.last_request.json() == {
+        "template_id": "456",
+        "email_address": "to@example.com",
+        "personalisation": {"name": "chris", "link": "https://www.safe-link.gov.uk"},
+        "sanitise_content_for": ["name"],
+    }
+
+
 def test_create_email_notification_with_one_click_unsubscribe_url(notifications_client, rmock):
     endpoint = f"{TEST_HOST}/v2/notifications/email"
     rmock.request("POST", endpoint, json={"status": "success"}, status_code=200)


### PR DESCRIPTION
So that users can tell us to sanitise content for specific placeholders. This is part of the work to mitigate against the placeholder injection vulnerability.

<!--Thanks for contributing to GOV.UK Notify. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?
<!--- Describe why you’re making this change -->

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [] I’ve written unit tests for these changes
- [ ] I’ve updated the documentation in
  - [ ] [notifications-tech-docs repository](https://github.com/alphagov/notifications-tech-docs/blob/main/source/documentation/client_docs/_python.md)
  - [] `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - [ ] `notifications_python_client/__init__.py`
- [ ] I've added new environment variables to
  - [ ] `notifications-python-client/scripts/generate_docker_env.sh`
  - [ ] `notifications-python-client/tox.ini`
  - [ ] `CONTRIBUTING.md`
