### PR TITLE
feat: document personalisation on get template responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 12.2.0
+
+* Document `personalisation` on template responses from `get_template`, `get_template_version` and `get_all_templates`. This is an object of placeholder names, for example `{"name": {"required": True}}`.
+
 ## 12.1.0
 
 * Adds `sanitise_content_for` parameter to `send_email_notification` endpoint. See [our documentation](https://docs.notifications.service.gov.uk/python.html#reducing-the-risk-of-malicious-content-injection-in-placeholders) for guidance on how to use this.

--- a/integration_test/schemas/v2/template_schemas.py
+++ b/integration_test/schemas/v2/template_schemas.py
@@ -26,6 +26,13 @@ get_template_by_id_response = {
         "body": {"type": "string"},
         "subject": {"type": ["string", "null"]},
         "letter_contact_block": {"type": ["string", "null"]},
+        "personalisation": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {"required": {"type": "boolean"}},
+            },
+        },
     },
     "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body"],
 }

--- a/notifications_python_client/__init__.py
+++ b/notifications_python_client/__init__.py
@@ -7,7 +7,7 @@
 #
 # -- http://semver.org/
 
-__version__ = "12.1.0"
+__version__ = "12.2.0"
 
 from notifications_python_client.errors import (  # noqa
     REQUEST_ERROR_MESSAGE,

--- a/tests/notifications_python_client/test_notifications_api_client.py
+++ b/tests/notifications_python_client/test_notifications_api_client.py
@@ -400,6 +400,20 @@ def test_get_template(notifications_client, rmock):
     assert rmock.called
 
 
+def test_get_template_returns_personalisation(notifications_client, rmock):
+    endpoint = f"{TEST_HOST}/v2/template/{123}"
+    rmock.request(
+        "GET",
+        endpoint,
+        json={"id": "123", "personalisation": {"name": {"required": True}}},
+        status_code=200,
+    )
+
+    response = notifications_client.get_template(123)
+
+    assert response["personalisation"] == {"name": {"required": True}}
+
+
 def test_get_template_version(notifications_client, rmock):
     endpoint = f"{TEST_HOST}/v2/template/123/version/1"
     rmock.request("GET", endpoint, json={"status": "success"}, status_code=200)


### PR DESCRIPTION
## Summary
- Get template responses already included `personalisation`. This change documents it in the schema and tests.
